### PR TITLE
Xml validation

### DIFF
--- a/src/main/java/net/maritimeconnectivity/serviceregistry/controllers/XmlController.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/controllers/XmlController.java
@@ -18,10 +18,14 @@ package net.maritimeconnectivity.serviceregistry.controllers;
 
 import lombok.extern.slf4j.Slf4j;
 import net.maritimeconnectivity.serviceregistry.exceptions.DataNotFoundException;
+import net.maritimeconnectivity.serviceregistry.models.domain.Instance;
 import net.maritimeconnectivity.serviceregistry.models.domain.Xml;
 import net.maritimeconnectivity.serviceregistry.services.XmlService;
 import net.maritimeconnectivity.serviceregistry.utils.HeaderUtil;
 import net.maritimeconnectivity.serviceregistry.utils.PaginationUtil;
+import org.efficiensea2.maritime_cloud.service_registry.v1.servicedesignschema.ServiceDesign;
+import org.efficiensea2.maritime_cloud.service_registry.v1.serviceinstanceschema.ServiceInstance;
+import org.efficiensea2.maritime_cloud.service_registry.v1.servicespecificationschema.ServiceSpecification;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -30,6 +34,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.xml.bind.JAXBException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -146,6 +151,66 @@ public class XmlController {
         return ResponseEntity.ok()
                 .headers(HeaderUtil.createEntityDeletionAlert("xml", id.toString()))
                 .build();
+    }
+
+    /**
+     * POST  /xmls/validate/design : Validates the provided XML schema based
+     * on the G1128 design specification schema.
+     *
+     * @param content the xml content to be validated
+     * @return the ResponseEntity with status 201 (Created) and with body of the G1128 design specification,
+     * or with status 400 (Bad Request) if the content is invalid
+     */
+    @PostMapping(value = "/xmls/validate/design", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Object> validateDesignXml(@Valid @RequestBody String content) {
+        log.debug("REST request to validate design xml : {}", content);
+        try {
+            return ResponseEntity.ok()
+                    .body(this.xmlService.validate(content, ServiceDesign.class));
+        } catch (JAXBException ex) {
+            return ResponseEntity.badRequest()
+                    .build();
+        }
+    }
+
+    /**
+     * POST  /xmls/validate/service : Validates the provided XML schema based
+     * on the G1128 service specification schema.
+     *
+     * @param content the xml content to be validated
+     * @return the ResponseEntity with status 201 (Created) and with body of the G1128 service specification,
+     * or with status 400 (Bad Request) if the content is invalid
+     */
+    @PostMapping(value = "/xmls/validate/service", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Object> validateServiceXml(@Valid @RequestBody String content) {
+        log.debug("REST request to validate service xml : {}", content);
+        try {
+            return ResponseEntity.ok()
+                    .body(this.xmlService.validate(content, ServiceSpecification.class));
+        } catch (JAXBException ex) {
+            return ResponseEntity.badRequest()
+                    .build();
+        }
+    }
+
+    /**
+     * POST  /xmls/validate/instance : Validates the provided XML schema based
+     * on the G1128 instance specification schema.
+     *
+     * @param content the xml content to be validated
+     * @return the ResponseEntity with status 200 (Created) and with body of the G1128 instance specification,
+     * or with status 400 (Bad Request) if the content is invalid
+     */
+    @PostMapping(value = "/xmls/validate/instance", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Object> validateInstanceXml(@RequestBody String content) {
+        log.debug("REST request to validate instance xml : {}", content);
+        try {
+            return ResponseEntity.ok()
+                    .body(this.xmlService.validate(content, ServiceInstance.class));
+        } catch (JAXBException ex) {
+            return ResponseEntity.badRequest()
+                    .build();
+        }
     }
 
 }

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/controllers/XmlController.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/controllers/XmlController.java
@@ -158,7 +158,7 @@ public class XmlController {
      * on the G1128 design specification schema.
      *
      * @param content the xml content to be validated
-     * @return the ResponseEntity with status 201 (Created) and with body of the G1128 design specification,
+     * @return the ResponseEntity with status 200 (OK) and with body of the G1128 design specification,
      * or with status 400 (Bad Request) if the content is invalid
      */
     @PostMapping(value = "/xmls/validate/design", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -178,7 +178,7 @@ public class XmlController {
      * on the G1128 service specification schema.
      *
      * @param content the xml content to be validated
-     * @return the ResponseEntity with status 201 (Created) and with body of the G1128 service specification,
+     * @return the ResponseEntity with status 200 (OK) and with body of the G1128 service specification,
      * or with status 400 (Bad Request) if the content is invalid
      */
     @PostMapping(value = "/xmls/validate/service", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -198,7 +198,7 @@ public class XmlController {
      * on the G1128 instance specification schema.
      *
      * @param content the xml content to be validated
-     * @return the ResponseEntity with status 200 (Created) and with body of the G1128 instance specification,
+     * @return the ResponseEntity with status 200 (OK) and with body of the G1128 instance specification,
      * or with status 400 (Bad Request) if the content is invalid
      */
     @PostMapping(value = "/xmls/validate/instance", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/services/XmlService.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/services/XmlService.java
@@ -20,12 +20,16 @@ import lombok.extern.slf4j.Slf4j;
 import net.maritimeconnectivity.serviceregistry.exceptions.DataNotFoundException;
 import net.maritimeconnectivity.serviceregistry.models.domain.Xml;
 import net.maritimeconnectivity.serviceregistry.repos.XmlRepo;
+import net.maritimeconnectivity.serviceregistry.utils.G1128Utils;
+import org.efficiensea2.maritime_cloud.service_registry.v1.serviceinstanceschema.ServiceInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.xml.bind.JAXBException;
 
 /**
  * Service Implementation for managing Xml.
@@ -93,6 +97,19 @@ public class XmlService {
         } else {
             throw new DataNotFoundException("No xml found for the provided ID", null);
         }
+    }
+
+    /**
+     * This function accepts an XML content as an input, as well as the G1128
+     * specification schema, in order to validate whether the input is actually
+     * correct.
+     *
+     * @param content the XML content
+     * @param g1128Schema the class of the G1128 schema to validate the content with
+     * @return the generated G1128 specification object
+     */
+    public Object validate(String content, Class<?> g1128Schema) throws JAXBException {
+        return new G1128Utils<>(g1128Schema).unmarshallG1128(content);
     }
 
 }

--- a/src/test/java/net/maritimeconnectivity/serviceregistry/controllers/XmlControllerTest.java
+++ b/src/test/java/net/maritimeconnectivity/serviceregistry/controllers/XmlControllerTest.java
@@ -20,6 +20,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import net.maritimeconnectivity.serviceregistry.exceptions.DataNotFoundException;
 import net.maritimeconnectivity.serviceregistry.models.domain.Xml;
 import net.maritimeconnectivity.serviceregistry.services.XmlService;
+import org.efficiensea2.maritime_cloud.service_registry.v1.servicedesignschema.ServiceDesign;
+import org.efficiensea2.maritime_cloud.service_registry.v1.serviceinstanceschema.ServiceInstance;
+import org.efficiensea2.maritime_cloud.service_registry.v1.servicespecificationschema.ServiceSpecification;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
@@ -38,12 +41,15 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
+import javax.xml.bind.JAXBException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -247,6 +253,108 @@ class XmlControllerTest {
         // Perform the MVC request
         this.mockMvc.perform(delete("/api/xmls/{id}", this.existingXml.getId()))
                 .andExpect(status().isNotFound());
+    }
+
+    /**
+     * Test that we can validate correctly a G1128 design specification XML.
+     */
+    @Test
+    void testValidateXmlDesign() throws Exception {
+        doReturn(new ServiceDesign()).when(this.xmlService).validate(any(), eq(ServiceDesign.class));
+        String xml = "<serviceDesign></serviceDesign>";
+
+        // Perform the MVC request
+        MvcResult mvcResult = this.mockMvc.perform(post("/api/xmls/validate/design")
+                .content(xml))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // Parse and validate the response
+        ServiceDesign result = this.objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ServiceDesign.class);
+        assertNotNull(result);
+    }
+
+    /**
+     * Test that we can detect when the provided G1128 design specification
+     * XML is invalid.
+     */
+    @Test
+    void testValidateXmlDesignFails() throws Exception {
+        doThrow(JAXBException.class).when(this.xmlService).validate(any(), eq(ServiceDesign.class));
+        String xml = "<serviceDesign></serviceDesign>";
+
+        // Perform the MVC request
+        this.mockMvc.perform(post("/api/xmls/validate/design")
+                .content(xml))
+                .andExpect(status().isBadRequest());
+    }
+
+    /**
+     * Test that we can validate correctly a G1128 service specification XML.
+     */
+    @Test
+    void testValidateXmlService() throws Exception {
+        doReturn(new ServiceSpecification()).when(this.xmlService).validate(any(), eq(ServiceSpecification.class));
+        String xml = "<serviceSpecification></serviceSpecification>";
+
+        // Perform the MVC request
+        MvcResult mvcResult = this.mockMvc.perform(post("/api/xmls/validate/service")
+                .content(xml))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // Parse and validate the response
+        ServiceSpecification result = this.objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ServiceSpecification.class);
+        assertNotNull(result);
+    }
+
+    /**
+     * Test that we can detect when the provided G1128 service specification
+     * XML is invalid.
+     */
+    @Test
+    void testValidateXmlServiceFails() throws Exception {
+        doThrow(JAXBException.class).when(this.xmlService).validate(any(), eq(ServiceSpecification.class));
+        String xml = "<serviceSpecification></serviceSpecification>";
+
+        // Perform the MVC request
+        this.mockMvc.perform(post("/api/xmls/validate/service")
+                .content(xml))
+                .andExpect(status().isBadRequest());
+    }
+
+    /**
+     * Test that we can validate correctly a G1128 instance specification XML.
+     */
+    @Test
+    void testValidateXmlInstance() throws Exception {
+        doReturn(new ServiceDesign()).when(this.xmlService).validate(any(), eq(ServiceInstance.class));
+        String xml = "<serviceInstance></serviceInstance>";
+
+        // Perform the MVC request
+        MvcResult mvcResult = this.mockMvc.perform(post("/api/xmls/validate/instance")
+                .content(xml))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // Parse and validate the response
+        ServiceInstance result = this.objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ServiceInstance.class);
+        assertNotNull(result);
+    }
+
+    /**
+     * Test that we can detect when the provided G1128 instance specification
+     * XML is invalid.
+     */
+    @Test
+    void testValidateXmlInstanceFails() throws Exception {
+        doThrow(JAXBException.class).when(this.xmlService).validate(any(), eq(ServiceInstance.class));
+        String xml = "<serviceInstance></serviceInstance>";
+
+        // Perform the MVC request
+        this.mockMvc.perform(post("/api/xmls/validate/instance")
+                .content(xml))
+                .andExpect(status().isBadRequest());
     }
 
 }

--- a/src/test/java/net/maritimeconnectivity/serviceregistry/services/XmlServiceTest.java
+++ b/src/test/java/net/maritimeconnectivity/serviceregistry/services/XmlServiceTest.java
@@ -21,6 +21,8 @@ import net.maritimeconnectivity.serviceregistry.exceptions.XMLValidationExceptio
 import net.maritimeconnectivity.serviceregistry.models.domain.Instance;
 import net.maritimeconnectivity.serviceregistry.models.domain.Xml;
 import net.maritimeconnectivity.serviceregistry.repos.XmlRepo;
+import org.apache.commons.io.IOUtils;
+import org.efficiensea2.maritime_cloud.service_registry.v1.serviceinstanceschema.ServiceInstance;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,11 +30,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import javax.xml.bind.JAXBException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -202,6 +209,53 @@ class XmlServiceTest {
         // Perform the service call
         assertThrows(DataNotFoundException.class, () ->
                 this.xmlService.delete(this.existingXml.getId())
+        );
+    }
+
+    /**
+     * Test that we can successfully validate whether an XML content follows
+     * the G1128 specification.
+     * @throws IOException when the test XML input file cannot be read
+     * @throws JAXBException for any JAXB parsing exceptions
+     */
+    @Test
+    void testValidate() throws IOException, JAXBException {
+        // Read a test service instance specification
+        InputStream in = new ClassPathResource("test-instance.xml").getInputStream();
+        String xml = IOUtils.toString(in, StandardCharsets.UTF_8.name());
+
+        // Perform the serviec call
+        ServiceInstance serviceInstance = (ServiceInstance) this.xmlService.validate(xml, ServiceInstance.class);
+
+        // Assert all information exists
+        assertNotNull(serviceInstance);
+        assertNotNull(serviceInstance.getName());
+        assertNotNull(serviceInstance.getVersion());
+        assertNotNull(serviceInstance.getId());
+        assertNotNull( serviceInstance.getKeywords());
+        assertNotNull(serviceInstance.getStatus());
+        assertNotNull(serviceInstance.getDescription());
+        assertNotNull(serviceInstance.getEndpoint());
+        assertNotNull(serviceInstance.getMMSI());
+        assertNotNull(serviceInstance.getIMO());
+        assertNotNull(serviceInstance.getServiceType());
+        assertNotNull(serviceInstance.getCoversAreas());
+        assertNotNull(serviceInstance.getProducedBy());
+        assertNotNull(serviceInstance.getProvidedBy());
+    }
+
+    /**
+     * Test that for an invalid input, the validation function will throw
+     * a JAXBException which can then be caught.
+     */
+    @Test
+    void testValidateFails() {
+        // Create a test invalid input
+        String xml = "Some invalid input";
+
+        // Perform the serviec call
+        assertThrows(JAXBException.class, () ->
+                this.xmlService.validate(xml, ServiceInstance.class)
         );
     }
 

--- a/src/test/resources/test-instance.xml
+++ b/src/test/resources/test-instance.xml
@@ -8,6 +8,9 @@
     <description>A simple service implementing a custom service specification</description>
     <keywords>test mcp navigation</keywords>
     <endpoint>https://testservice.mcp.enav.org/service/endpoint/</endpoint>
+    <MMSI>123456789</MMSI>
+    <IMO>987654321</IMO>
+    <serviceType>test</serviceType>
     <requiresAuthorization>true</requiresAuthorization>
     <offersServiceLevel>
         <availability>0</availability>


### PR DESCRIPTION
Adding three xml controller endpoints, one for each of the G1128 schemas, to validate the XML in the body of the POSTs.