### PR TITLE
Adding an endpoint for the G1128 schemas

### DIFF
--- a/src/main/java/net/maritimeconnectivity/serviceregistry/config/WebConfig.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/config/WebConfig.java
@@ -16,6 +16,7 @@
 
 package net.maritimeconnectivity.serviceregistry.config;
 
+import net.maritimeconnectivity.serviceregistry.utils.StringToG1128SchemaConverter;
 import net.maritimeconnectivity.serviceregistry.utils.StringToServiceStatusConverter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
@@ -60,14 +61,15 @@ public class WebConfig implements WebMvcConfigurer {
     }
 
     /**
-     * Add the converter between strings and the G1128 Service Instance status
-     * enumeration.
+     * Add the converters between strings and the G1128 Service Instance status
+     * and the G1128 Schemas enumerations.
      *
      * @param registry the Formatter Registry
      */
     @Override
     public void addFormatters(FormatterRegistry registry) {
         registry.addConverter(new StringToServiceStatusConverter());
+        registry.addConverter(new StringToG1128SchemaConverter());
     }
 
 }

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/config/WebSecurityConfig.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/config/WebSecurityConfig.java
@@ -150,7 +150,8 @@ class WebSecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
                     "/webjars/**",  //bootstrap
                     "/css/**",                  //css files
                     "/js/**",                   //js files
-                    "/favicon.ico"              //the favicon
+                    "/favicon.ico",             //the favicon
+                    "/api/xmls/schemas/*"       //the G1128 schemas
                 );
     }
 

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/controllers/XmlController.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/controllers/XmlController.java
@@ -19,24 +19,27 @@ package net.maritimeconnectivity.serviceregistry.controllers;
 import lombok.extern.slf4j.Slf4j;
 import net.maritimeconnectivity.serviceregistry.exceptions.DataNotFoundException;
 import net.maritimeconnectivity.serviceregistry.models.domain.Xml;
+import net.maritimeconnectivity.serviceregistry.models.domain.enums.G1128Schemas;
 import net.maritimeconnectivity.serviceregistry.services.XmlService;
 import net.maritimeconnectivity.serviceregistry.utils.HeaderUtil;
 import net.maritimeconnectivity.serviceregistry.utils.PaginationUtil;
-import org.efficiensea2.maritime_cloud.service_registry.v1.servicedesignschema.ServiceDesign;
-import org.efficiensea2.maritime_cloud.service_registry.v1.serviceinstanceschema.ServiceInstance;
-import org.efficiensea2.maritime_cloud.service_registry.v1.servicespecificationschema.ServiceSpecification;
+import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import javax.xml.bind.JAXBException;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * REST controller for managing Xml.
@@ -55,7 +58,7 @@ public class XmlController {
     private XmlService xmlService;
 
     /**
-     * GET  /xmls : get all the xmls.
+     * GET /xmls : get all the xmls.
      *
      * @param pageable the pagination information
      * @return the ResponseEntity with status 200 (OK) and the list of xmls in body
@@ -72,7 +75,7 @@ public class XmlController {
     }
 
     /**
-     * GET  /xmls/{id} : get the "ID" xml.
+     * GET /xmls/{id} : get the "ID" xml.
      *
      * @param id the ID of the xml to retrieve
      * @return the ResponseEntity with status 200 (OK) and with body the xml,
@@ -92,7 +95,7 @@ public class XmlController {
     }
 
     /**
-     * POST  /xmls : Create a new xml.
+     * POST /xmls : Create a new xml.
      *
      * @param xml the xml to create
      * @return the ResponseEntity with status 201 (Created) and with body the new xml,
@@ -114,7 +117,7 @@ public class XmlController {
     }
 
     /**
-     * PUT  /xmls/{id} : Updates an existing xml.
+     * PUT /xmls/{id} : Updates an existing xml.
      *
      * @param id the ID of the xml to be updated
      * @param xml the xml to update
@@ -133,7 +136,7 @@ public class XmlController {
     }
 
     /**
-     * DELETE  /xmls/{id} : delete the "id" xml.
+     * DELETE /xmls/{id} : delete the "id" xml.
      *
      * @param id the id of the xml to delete
      * @return the ResponseEntity with status 200 (OK)
@@ -153,63 +156,48 @@ public class XmlController {
     }
 
     /**
-     * POST  /xmls/validate/design : Validates the provided XML schema based
-     * on the G1128 design specification schema.
+     * GET /xmls/schemas/{schema} : Returns the requested G1128 schema
+     * specification, as it is loaded in the classpath.
+     *
+     * @return the ResponseEntity with status 200 (OK) and with body of the G1128 schema specification,
+     * or with status 404 (Not Found) if the schema is not found
+     */
+    @GetMapping(value = "/xmls/schemas/{schema}", produces = MediaType.APPLICATION_XML_VALUE)
+    public ResponseEntity<String> getG1128Schema(@PathVariable G1128Schemas schema) {
+        HttpHeaders responseHeaders = new HttpHeaders();
+        responseHeaders.add(HttpHeaders.CONTENT_TYPE, new MediaType(MediaType.APPLICATION_XML, StandardCharsets.UTF_8).toString());
+        return Optional.of(schema)
+                .map(sc -> getClass().getClassLoader().getResourceAsStream(sc.getPath()))
+                .map(is -> {
+                    try {
+                        return IOUtils.toString(is, StandardCharsets.UTF_8.name());
+                    } catch (IOException e) {
+                        return null;
+                    }
+                })
+                .map(xml -> ResponseEntity.ok().headers(responseHeaders).body(xml))
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    /**
+     * POST /xmls/validate/{schema{}} : Validates the provided XML input based
+     * on the specified G1128 schema specification.
      *
      * @param content the xml content to be validated
-     * @return the ResponseEntity with status 200 (OK) and with body of the G1128 design specification,
+     * @return the ResponseEntity with status 200 (OK) and with body of the parsed G1128-compliant object,
      * or with status 400 (Bad Request) if the content is invalid
      */
-    @PostMapping(value = "/xmls/validate/design", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Object> validateDesignXml(@Valid @RequestBody String content) {
+    @PostMapping(value = "/xmls/validate/{schema}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Object> validateXmlWithG1128Schema(@PathVariable G1128Schemas schema, @Valid @RequestBody String content) {
         log.debug("REST request to validate design xml : {}", content);
         try {
             return ResponseEntity.ok()
-                    .body(this.xmlService.validate(content, ServiceDesign.class));
-        } catch (JAXBException ex) {
+                    .body(this.xmlService.validate(content, schema));
+        } catch (JAXBException | DataNotFoundException ex) {
             return ResponseEntity.badRequest()
                     .build();
         }
     }
 
-    /**
-     * POST  /xmls/validate/service : Validates the provided XML schema based
-     * on the G1128 service specification schema.
-     *
-     * @param content the xml content to be validated
-     * @return the ResponseEntity with status 200 (OK) and with body of the G1128 service specification,
-     * or with status 400 (Bad Request) if the content is invalid
-     */
-    @PostMapping(value = "/xmls/validate/service", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Object> validateServiceXml(@Valid @RequestBody String content) {
-        log.debug("REST request to validate service xml : {}", content);
-        try {
-            return ResponseEntity.ok()
-                    .body(this.xmlService.validate(content, ServiceSpecification.class));
-        } catch (JAXBException ex) {
-            return ResponseEntity.badRequest()
-                    .build();
-        }
-    }
-
-    /**
-     * POST  /xmls/validate/instance : Validates the provided XML schema based
-     * on the G1128 instance specification schema.
-     *
-     * @param content the xml content to be validated
-     * @return the ResponseEntity with status 200 (OK) and with body of the G1128 instance specification,
-     * or with status 400 (Bad Request) if the content is invalid
-     */
-    @PostMapping(value = "/xmls/validate/instance", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Object> validateInstanceXml(@RequestBody String content) {
-        log.debug("REST request to validate instance xml : {}", content);
-        try {
-            return ResponseEntity.ok()
-                    .body(this.xmlService.validate(content, ServiceInstance.class));
-        } catch (JAXBException ex) {
-            return ResponseEntity.badRequest()
-                    .build();
-        }
-    }
 
 }

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/models/domain/Instance.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/models/domain/Instance.java
@@ -92,7 +92,7 @@ public class Instance implements Serializable {
 
     @NotNull
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", columnDefinition = "varchar(30) default 'Pending Validation'")
+    @Column(name = "status", columnDefinition = "varchar(30) default 'provisional'")
     private ServiceStatus status;
 
     @Column(name = "organization_id")

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/models/domain/enums/G1128Schemas.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/models/domain/enums/G1128Schemas.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2021 Maritime Connectivity Platform Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.maritimeconnectivity.serviceregistry.models.domain.enums;
+
+import org.efficiensea2.maritime_cloud.service_registry.v1.servicedesignschema.ServiceDesign;
+import org.efficiensea2.maritime_cloud.service_registry.v1.serviceinstanceschema.ServiceInstance;
+import org.efficiensea2.maritime_cloud.service_registry.v1.servicespecificationschema.ServiceSpecification;
+
+/**
+ * The G1128 Schemas Enumeration.
+ * <p>
+ * To allow easy access to the G1128 schema definitions from the G1128
+ * package, this enum contains all available XSD file names and classpath
+ * locations as an enum.
+ *
+ * @author Nikolaos Vastardis (email: Nikolaos.Vastardis@gla-rad.org)
+ */
+public enum G1128Schemas {
+    BASE("base", "xsd/ServiceBaseTypesSchema.xsd", null),
+    DESIGN("design", "xsd/ServiceDesignSchema.xsd", ServiceDesign.class),
+    SERVICE("service", "xsd/ServiceSpecificationSchema.xsd", ServiceSpecification.class),
+    INSTANCE("instance", "xsd/ServiceInstanceSchema.xsd", ServiceInstance.class);
+
+    // Enum Variables
+    private String name;
+    private String path;
+    private Class schemaClass;
+
+    /**
+     * The G1128 Schema Enumeration Constructor.
+     *
+     * @param name the schema name
+     * @param path the schema path
+     */
+    G1128Schemas(String name, String path, Class schemaClass) {
+        this.name = name;
+        this.path = path;
+        this.schemaClass = schemaClass;
+    }
+
+    /**
+     * Gets name.
+     *
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets name.
+     *
+     * @param name the name
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Gets path.
+     *
+     * @return the path
+     */
+    public String getPath() {
+        return path;
+    }
+
+    /**
+     * Sets path.
+     *
+     * @param path the path
+     */
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    /**
+     * Gets schema class.
+     *
+     * @return the schema class
+     */
+    public Class getSchemaClass() {
+        return schemaClass;
+    }
+
+    /**
+     * Sets schema class.
+     *
+     * @param schemaClass the schema class
+     */
+    public void setSchemaClass(Class schemaClass) {
+        this.schemaClass = schemaClass;
+    }
+}

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/services/InstanceService.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/services/InstanceService.java
@@ -86,16 +86,6 @@ public class InstanceService {
     private UserContext userContext;
 
     /**
-     * Definition of the G1128 Schema Sources.
-     */
-    List<String> g1128Sources = Arrays.asList(new String[] {
-            "xsd/ServiceBaseTypesSchema.xsd",
-            "xsd/ServiceDesignSchema.xsd",
-            "xsd/ServiceSpecificationSchema.xsd",
-            "xsd/ServiceInstanceSchema.xsd"
-    });
-
-    /**
      * Definition of the whole world area in GeoJSON.
      */
     String wholeWorldGeoJson = "{\n" +
@@ -294,7 +284,7 @@ public class InstanceService {
         }
 
         try {
-            XmlUtil.validateXml(instance.getInstanceAsXml().getContent(), this.g1128Sources);
+            XmlUtil.validateXml(instance.getInstanceAsXml().getContent(), G1128Utils.SOURCES_LIST);
         } catch (SAXException e) {
             throw new XMLValidationException("Service Instance XML is not valid.", e);
         } catch (IOException e) {

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/services/XmlService.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/services/XmlService.java
@@ -19,9 +19,9 @@ package net.maritimeconnectivity.serviceregistry.services;
 import lombok.extern.slf4j.Slf4j;
 import net.maritimeconnectivity.serviceregistry.exceptions.DataNotFoundException;
 import net.maritimeconnectivity.serviceregistry.models.domain.Xml;
+import net.maritimeconnectivity.serviceregistry.models.domain.enums.G1128Schemas;
 import net.maritimeconnectivity.serviceregistry.repos.XmlRepo;
 import net.maritimeconnectivity.serviceregistry.utils.G1128Utils;
-import org.efficiensea2.maritime_cloud.service_registry.v1.serviceinstanceschema.ServiceInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -30,6 +30,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.xml.bind.JAXBException;
+import java.util.Optional;
 
 /**
  * Service Implementation for managing Xml.
@@ -105,11 +106,16 @@ public class XmlService {
      * correct.
      *
      * @param content the XML content
-     * @param g1128Schema the class of the G1128 schema to validate the content with
+     * @param schema the G1128 schema to validate the content with
      * @return the generated G1128 specification object
      */
-    public Object validate(String content, Class<?> g1128Schema) throws JAXBException {
-        return new G1128Utils<>(g1128Schema).unmarshallG1128(content);
+    public Object validate(String content, G1128Schemas schema) throws JAXBException, DataNotFoundException {
+        // Make sure we have a valid G1128 schema class to work with
+        Class schemaClass = Optional.of(schema)
+                .map(G1128Schemas::getSchemaClass)
+                .orElseThrow(() -> new DataNotFoundException("Invalid G1128 schema selection", null));
+        // And validate the content
+        return new G1128Utils<>(schemaClass).unmarshallG1128(content);
     }
 
 }

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/utils/G1128Utils.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/utils/G1128Utils.java
@@ -16,12 +16,24 @@
 
 package net.maritimeconnectivity.serviceregistry.utils;
 
+import net.maritimeconnectivity.serviceregistry.models.domain.enums.G1128Schemas;
+
 import javax.xml.bind.*;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.List;
 
 public class G1128Utils<T> {
+
+    // Create a public definition of all the G1128 sources
+    public static List<String> SOURCES_LIST = Arrays.asList(new String[]{
+            G1128Schemas.BASE.getPath(),
+            G1128Schemas.DESIGN.getPath(),
+            G1128Schemas.SERVICE.getPath(),
+            G1128Schemas.INSTANCE.getPath(),
+    });
 
     // Class Variables
     private Class<T> g1128Spec;

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/utils/StringToG1128SchemaConverter.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/utils/StringToG1128SchemaConverter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021 Maritime Connectivity Platform Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.maritimeconnectivity.serviceregistry.utils;
+
+import net.maritimeconnectivity.serviceregistry.models.domain.enums.G1128Schemas;
+import org.springframework.core.convert.converter.Converter;
+
+/**
+ * The Sting to G1128 Schemas Converter.
+ *
+ * This utility class can convert strings to G1128 Schemas enumeration entries.
+ *
+ * @author Nikolaos Vastardis (email: Nikolaos.Vastardis@gla-rad.org)
+ */
+public class StringToG1128SchemaConverter implements Converter<String, G1128Schemas> {
+
+    @Override
+    public G1128Schemas convert(String source) {
+        for (G1128Schemas s : G1128Schemas.values()) {
+            if (s.getName().equalsIgnoreCase(source)) {
+                return s;
+            }
+        }
+        return null;
+    }
+
+}

--- a/src/test/java/net/maritimeconnectivity/serviceregistry/controllers/XmlControllerTest.java
+++ b/src/test/java/net/maritimeconnectivity/serviceregistry/controllers/XmlControllerTest.java
@@ -19,7 +19,9 @@ package net.maritimeconnectivity.serviceregistry.controllers;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import net.maritimeconnectivity.serviceregistry.exceptions.DataNotFoundException;
 import net.maritimeconnectivity.serviceregistry.models.domain.Xml;
+import net.maritimeconnectivity.serviceregistry.models.domain.enums.G1128Schemas;
 import net.maritimeconnectivity.serviceregistry.services.XmlService;
+import org.apache.commons.io.IOUtils;
 import org.efficiensea2.maritime_cloud.service_registry.v1.servicedesignschema.ServiceDesign;
 import org.efficiensea2.maritime_cloud.service_registry.v1.serviceinstanceschema.ServiceInstance;
 import org.efficiensea2.maritime_cloud.service_registry.v1.servicespecificationschema.ServiceSpecification;
@@ -42,6 +44,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import javax.xml.bind.JAXBException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -256,15 +260,89 @@ class XmlControllerTest {
     }
 
     /**
+     * Test that we can retrieve the G1128 Design Specification schema
+     * correctly.
+     */
+    @Test
+    void testGetG1128SchemaDesign() throws Exception {
+        // Get the G1128 Design schema to test with
+        G1128Schemas schema = G1128Schemas.DESIGN;
+        InputStream is = getClass().getClassLoader().getResourceAsStream(schema.getPath());
+        String schemaXml = IOUtils.toString(is, StandardCharsets.UTF_8.name());
+
+        // Perform the MVC request
+        MvcResult mvcResult = this.mockMvc.perform(get("/api/xmls/schemas/{schema}", schema.getName()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(new MediaType(MediaType.APPLICATION_XML, StandardCharsets.UTF_8)))
+                .andReturn();
+
+        // Make sure the retrieved schema is correct
+        assertEquals(schemaXml, mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * Test that we can retrieve the G1128 Service Specification schema
+     * correctly.
+     */
+    @Test
+    void testGetG1128SchemaService() throws Exception {
+        // Get the G1128 Design schema to test with
+        G1128Schemas schema = G1128Schemas.SERVICE;
+        InputStream is = getClass().getClassLoader().getResourceAsStream(schema.getPath());
+        String schemaXml = IOUtils.toString(is, StandardCharsets.UTF_8.name());
+
+        // Perform the MVC request
+        MvcResult mvcResult = this.mockMvc.perform(get("/api/xmls/schemas/{schema}", schema.getName()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(new MediaType(MediaType.APPLICATION_XML, StandardCharsets.UTF_8)))
+                .andReturn();
+
+        // Make sure the retrieved schema is correct
+        assertEquals(schemaXml, mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * Test that we can retrieve the G1128 Instance Specification schema
+     * correctly.
+     */
+    @Test
+    void testGetG1128SchemaInstance() throws Exception {
+        // Get the G1128 Design schema to test with
+        G1128Schemas schema = G1128Schemas.INSTANCE;
+        InputStream is = getClass().getClassLoader().getResourceAsStream(schema.getPath());
+        String schemaXml = IOUtils.toString(is, StandardCharsets.UTF_8.name());
+
+        // Perform the MVC request
+        MvcResult mvcResult = this.mockMvc.perform(get("/api/xmls/schemas/{schema}", schema.getName()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(new MediaType(MediaType.APPLICATION_XML, StandardCharsets.UTF_8)))
+                .andReturn();
+
+        // Make sure the retrieved schema is correct
+        assertEquals(schemaXml, mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * Test that when we request an invalid G1128 Specification schema, then a
+     * 500 (INTERNAL_SERVER_ERROR) response will be returned.
+     */
+    @Test
+    void testGetG1128SchemaInvalid() throws Exception {
+        // Perform the MVC request
+        this.mockMvc.perform(get("/api/xmls/schemas/{schema}", "invalid"))
+                .andExpect(status().isInternalServerError());
+    }
+
+    /**
      * Test that we can validate correctly a G1128 design specification XML.
      */
     @Test
     void testValidateXmlDesign() throws Exception {
-        doReturn(new ServiceDesign()).when(this.xmlService).validate(any(), eq(ServiceDesign.class));
+        doReturn(new ServiceDesign()).when(this.xmlService).validate(any(), eq(G1128Schemas.DESIGN));
         String xml = "<serviceDesign></serviceDesign>";
 
         // Perform the MVC request
-        MvcResult mvcResult = this.mockMvc.perform(post("/api/xmls/validate/design")
+        MvcResult mvcResult = this.mockMvc.perform(post("/api/xmls/validate/{schema}", G1128Schemas.DESIGN.getName())
                 .content(xml))
                 .andExpect(status().isOk())
                 .andReturn();
@@ -280,11 +358,11 @@ class XmlControllerTest {
      */
     @Test
     void testValidateXmlDesignFails() throws Exception {
-        doThrow(JAXBException.class).when(this.xmlService).validate(any(), eq(ServiceDesign.class));
+        doThrow(JAXBException.class).when(this.xmlService).validate(any(), eq(G1128Schemas.DESIGN));
         String xml = "<serviceDesign></serviceDesign>";
 
         // Perform the MVC request
-        this.mockMvc.perform(post("/api/xmls/validate/design")
+        this.mockMvc.perform(post("/api/xmls/validate/{schema}", G1128Schemas.DESIGN.getName())
                 .content(xml))
                 .andExpect(status().isBadRequest());
     }
@@ -294,11 +372,11 @@ class XmlControllerTest {
      */
     @Test
     void testValidateXmlService() throws Exception {
-        doReturn(new ServiceSpecification()).when(this.xmlService).validate(any(), eq(ServiceSpecification.class));
+        doReturn(new ServiceSpecification()).when(this.xmlService).validate(any(), eq(G1128Schemas.SERVICE));
         String xml = "<serviceSpecification></serviceSpecification>";
 
         // Perform the MVC request
-        MvcResult mvcResult = this.mockMvc.perform(post("/api/xmls/validate/service")
+        MvcResult mvcResult = this.mockMvc.perform(post("/api/xmls/validate/{schema}", G1128Schemas.SERVICE.getName())
                 .content(xml))
                 .andExpect(status().isOk())
                 .andReturn();
@@ -314,11 +392,11 @@ class XmlControllerTest {
      */
     @Test
     void testValidateXmlServiceFails() throws Exception {
-        doThrow(JAXBException.class).when(this.xmlService).validate(any(), eq(ServiceSpecification.class));
+        doThrow(JAXBException.class).when(this.xmlService).validate(any(), eq(G1128Schemas.SERVICE));
         String xml = "<serviceSpecification></serviceSpecification>";
 
         // Perform the MVC request
-        this.mockMvc.perform(post("/api/xmls/validate/service")
+        this.mockMvc.perform(post("/api/xmls/validate/{schema}", G1128Schemas.SERVICE.getName())
                 .content(xml))
                 .andExpect(status().isBadRequest());
     }
@@ -328,11 +406,11 @@ class XmlControllerTest {
      */
     @Test
     void testValidateXmlInstance() throws Exception {
-        doReturn(new ServiceDesign()).when(this.xmlService).validate(any(), eq(ServiceInstance.class));
+        doReturn(new ServiceDesign()).when(this.xmlService).validate(any(), eq(G1128Schemas.INSTANCE));
         String xml = "<serviceInstance></serviceInstance>";
 
         // Perform the MVC request
-        MvcResult mvcResult = this.mockMvc.perform(post("/api/xmls/validate/instance")
+        MvcResult mvcResult = this.mockMvc.perform(post("/api/xmls/validate/{schema}", G1128Schemas.INSTANCE.getName())
                 .content(xml))
                 .andExpect(status().isOk())
                 .andReturn();
@@ -348,11 +426,11 @@ class XmlControllerTest {
      */
     @Test
     void testValidateXmlInstanceFails() throws Exception {
-        doThrow(JAXBException.class).when(this.xmlService).validate(any(), eq(ServiceInstance.class));
+        doThrow(JAXBException.class).when(this.xmlService).validate(any(), eq(G1128Schemas.INSTANCE));
         String xml = "<serviceInstance></serviceInstance>";
 
         // Perform the MVC request
-        this.mockMvc.perform(post("/api/xmls/validate/instance")
+        this.mockMvc.perform(post("/api/xmls/validate/{schema}", G1128Schemas.INSTANCE.getName())
                 .content(xml))
                 .andExpect(status().isBadRequest());
     }

--- a/src/test/java/net/maritimeconnectivity/serviceregistry/services/XmlServiceTest.java
+++ b/src/test/java/net/maritimeconnectivity/serviceregistry/services/XmlServiceTest.java
@@ -18,6 +18,7 @@ package net.maritimeconnectivity.serviceregistry.services;
 
 import net.maritimeconnectivity.serviceregistry.exceptions.DataNotFoundException;
 import net.maritimeconnectivity.serviceregistry.models.domain.Xml;
+import net.maritimeconnectivity.serviceregistry.models.domain.enums.G1128Schemas;
 import net.maritimeconnectivity.serviceregistry.repos.XmlRepo;
 import org.apache.commons.io.IOUtils;
 import org.efficiensea2.maritime_cloud.service_registry.v1.serviceinstanceschema.ServiceInstance;
@@ -217,13 +218,13 @@ class XmlServiceTest {
      * @throws JAXBException for any JAXB parsing exceptions
      */
     @Test
-    void testValidate() throws IOException, JAXBException {
+    void testValidate() throws IOException, JAXBException, DataNotFoundException {
         // Read a test service instance specification
         InputStream in = new ClassPathResource("test-instance.xml").getInputStream();
         String xml = IOUtils.toString(in, StandardCharsets.UTF_8.name());
 
         // Perform the serviec call
-        ServiceInstance serviceInstance = (ServiceInstance) this.xmlService.validate(xml, ServiceInstance.class);
+        ServiceInstance serviceInstance = (ServiceInstance) this.xmlService.validate(xml, G1128Schemas.INSTANCE);
 
         // Assert all information exists
         assertNotNull(serviceInstance);
@@ -243,6 +244,21 @@ class XmlServiceTest {
     }
 
     /**
+     * Test that when we don't have a valid G1128 schema class (e.g. for the
+     * G1128 BASE case), the validation will fail with a DataNotFoundException.
+     */
+    @Test
+    void testValidateNoClass() {
+        // Create a test invalid input
+        String xml = "Some random input";
+
+        // Perform the serviec call
+        assertThrows(DataNotFoundException.class, () ->
+                this.xmlService.validate(xml, G1128Schemas.BASE)
+        );
+    }
+
+    /**
      * Test that for an invalid input, the validation function will throw
      * a JAXBException which can then be caught.
      */
@@ -253,7 +269,7 @@ class XmlServiceTest {
 
         // Perform the serviec call
         assertThrows(JAXBException.class, () ->
-                this.xmlService.validate(xml, ServiceInstance.class)
+                this.xmlService.validate(xml, G1128Schemas.INSTANCE)
         );
     }
 

--- a/src/test/java/net/maritimeconnectivity/serviceregistry/utils/StringToG1128SchemaConverterTest.java
+++ b/src/test/java/net/maritimeconnectivity/serviceregistry/utils/StringToG1128SchemaConverterTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021 Maritime Connectivity Platform Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.maritimeconnectivity.serviceregistry.utils;
+
+import net.maritimeconnectivity.serviceregistry.models.domain.enums.G1128Schemas;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class StringToG1128SchemaConverterTest {
+
+    /**
+     * Test that we can convert a valid string (regardless of the casing) into
+     * the G1128 schemas enum.
+     */
+    @Test
+    void testConvert() {
+        StringToG1128SchemaConverter converter = new StringToG1128SchemaConverter();
+        assertEquals(G1128Schemas.BASE, converter.convert("base"));
+        assertEquals(G1128Schemas.BASE, converter.convert("Base"));
+        assertEquals(G1128Schemas.BASE, converter.convert("BASE"));
+        assertEquals(G1128Schemas.DESIGN, converter.convert("design"));
+        assertEquals(G1128Schemas.DESIGN, converter.convert("Design"));
+        assertEquals(G1128Schemas.DESIGN, converter.convert("DESIGN"));
+        assertEquals(G1128Schemas.SERVICE, converter.convert("service"));
+        assertEquals(G1128Schemas.SERVICE, converter.convert("Service"));
+        assertEquals(G1128Schemas.SERVICE, converter.convert("SERVICE"));
+        assertEquals(G1128Schemas.INSTANCE, converter.convert("instance"));
+        assertEquals(G1128Schemas.INSTANCE, converter.convert("Instance"));
+        assertEquals(G1128Schemas.INSTANCE, converter.convert("INSTANCE"));
+    }
+
+    /**
+     * Test that we for invalid input, the StringToG1128SchemaConverter will
+     * return null.
+     */
+    @Test
+    void testConvertInvalid() {
+        StringToG1128SchemaConverter converter = new StringToG1128SchemaConverter();
+        assertNull(converter.convert(null));
+        assertNull(converter.convert(""));
+        assertNull(converter.convert("invalid"));
+    }
+}

--- a/src/test/java/net/maritimeconnectivity/serviceregistry/utils/XmlUtilTest.java
+++ b/src/test/java/net/maritimeconnectivity/serviceregistry/utils/XmlUtilTest.java
@@ -17,7 +17,6 @@
 package net.maritimeconnectivity.serviceregistry.utils;
 
 import org.apache.commons.io.IOUtils;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ClassPathResource;
 import org.xml.sax.SAXException;
@@ -26,28 +25,11 @@ import org.xml.sax.SAXParseException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class XmlUtilTest {
-
-    // Test Variables
-    List<String> sources;
-
-    /**
-     * Common setup for all the tests.
-     */
-    @BeforeEach
-    void setUp() {
-        this.sources = Arrays.asList(new String[] {
-                "xsd/ServiceBaseTypesSchema.xsd",
-                "xsd/ServiceDesignSchema.xsd",
-                "xsd/ServiceSpecificationSchema.xsd",
-                "xsd/ServiceInstanceSchema.xsd"
-        });
-    }
 
     /**
      * Test that we can correctly validate an XML if compared to a valid XSD
@@ -57,7 +39,7 @@ class XmlUtilTest {
     void testValidateXmlTrue() throws IOException, SAXException {
         InputStream in = new ClassPathResource("test-instance.xml").getInputStream();
         String xml = IOUtils.toString(in, StandardCharsets.UTF_8.name());
-        assertTrue(XmlUtil.validateXml(xml, this.sources));
+        assertTrue(XmlUtil.validateXml(xml, G1128Utils.SOURCES_LIST));
     }
 
     /**
@@ -75,7 +57,7 @@ class XmlUtilTest {
 
         // And  the exception
         assertThrows(SAXParseException.class, () ->
-            XmlUtil.validateXml(wrongXml, this.sources)
+            XmlUtil.validateXml(wrongXml, G1128Utils.SOURCES_LIST)
         );
     }
 


### PR DESCRIPTION
As discussed, I have added an endpoint to allow users to access the G1128 schema files. This is not protected and is public for everyone.

To simplify the code, I created an enum (G1128Schemas) with all the necessary G1128 schema information and now all components are using this to access each schema's info (like the generated class of the classpath location).

Since we introduced the G1128Schemas, I also simplified the three controllers for validating the XML inputs, and now only one is required. The endpoint URL should be the same, since the last element of the path is now a path variable.