### PR TITLE
Instance Doc upload

### DIFF
--- a/src/main/java/net/maritimeconnectivity/serviceregistry/components/DomainDtoMapper.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/components/DomainDtoMapper.java
@@ -22,6 +22,7 @@ import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -51,6 +52,7 @@ public class DomainDtoMapper<F, T> {
      * @param clazz             The class to map the FROM objects to
      * @return the mapped TO object datatables page
      */
+    @Transactional
     public DtPage<T> convertToDtPage(Page<F> page, DtPagingRequest dtPagingRequest, Class<T> clazz) {
         return new DtPage<>(this.convertToPage(page, clazz), dtPagingRequest);
     }
@@ -62,6 +64,7 @@ public class DomainDtoMapper<F, T> {
      * @param clazz             The class to map the FROM objects to
      * @return the mapped TO object page
      */
+    @Transactional
     public Page<T> convertToPage(Page<F> page, Class<T> clazz) {
         return page.map(obj -> this.convertTo(obj, clazz));
     }
@@ -73,6 +76,7 @@ public class DomainDtoMapper<F, T> {
      * @param clazz             The class to map the FROM objects to
      * @return the mapped TO object list
      */
+    @Transactional
     public List<T> convertToList(List<F> list, Class<T> clazz) {
         return list.stream()
                 .map(obj -> this.convertTo(obj, clazz))
@@ -86,6 +90,7 @@ public class DomainDtoMapper<F, T> {
      * @param clazz             The class to map the FROM object to
      * @return the mapped TO object
      */
+    @Transactional
     public T convertTo(F fromObj, Class<T> clazz) {
         return this.modelMapper.map(fromObj, clazz);
     }

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/components/SmartContractProvider.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/components/SmartContractProvider.java
@@ -19,10 +19,9 @@ package net.maritimeconnectivity.serviceregistry.components;
 import lombok.extern.slf4j.Slf4j;
 import net.maritimeconnectivity.serviceregistry.models.domain.Instance;
 import net.maritimeconnectivity.serviceregistry.utils.MsrContract;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.locationtech.jts.geom.Geometry;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.annotation.SessionScope;
 import org.web3j.crypto.Credentials;
@@ -35,7 +34,6 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import java.io.IOException;
 import java.net.ConnectException;
-import java.net.UnknownHostException;
 import java.util.Optional;
 
 /**
@@ -144,7 +142,7 @@ public class SmartContractProvider {
                 instance.getInstanceId(),
                 instance.getVersion(),
                 instance.getKeywords(),
-                instance.getGeometry().toString(),
+                Optional.ofNullable(instance.getGeometry()).map(Geometry::toString).orElse(null),
                 "designMrn",
                 "designVersion",
                 new MsrContract.Msr(msrName, msrUrl)

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/controllers/InstanceController.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/controllers/InstanceController.java
@@ -22,6 +22,7 @@ import net.maritimeconnectivity.serviceregistry.exceptions.GeometryParseExceptio
 import net.maritimeconnectivity.serviceregistry.exceptions.XMLValidationException;
 import net.maritimeconnectivity.serviceregistry.models.domain.Instance;
 import net.maritimeconnectivity.serviceregistry.models.domain.enums.LedgerRequestStatus;
+import net.maritimeconnectivity.serviceregistry.models.dto.InstanceDtDto;
 import net.maritimeconnectivity.serviceregistry.models.dto.InstanceDto;
 import net.maritimeconnectivity.serviceregistry.models.dto.datatables.DtPage;
 import net.maritimeconnectivity.serviceregistry.models.dto.datatables.DtPagingRequest;
@@ -71,6 +72,12 @@ public class InstanceController {
     DomainDtoMapper<InstanceDto, Instance> instanceDtoToDomainMapper;
 
     /**
+     * Object Mapper from Domain to Datatable DTO.
+     */
+    @Autowired
+    DomainDtoMapper<Instance, InstanceDtDto> instanceDomainToDtDtoMapper;
+
+    /**
      * GET /api/instances : get all the instances.
      *
      * @param pageable the pagination information
@@ -94,11 +101,11 @@ public class InstanceController {
      * @return the ResponseEntity with status 200 (OK) and the list of stations in body
      */
     @PostMapping(value = "/dt", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<DtPage<InstanceDto>> getInstancesForDatatables(@RequestBody DtPagingRequest dtPagingRequest) {
+    public ResponseEntity<DtPage<InstanceDtDto>> getInstancesForDatatables(@RequestBody DtPagingRequest dtPagingRequest) {
         log.debug("REST request to get page of Instances for datatables");
         final Page<Instance> page = this.instanceService.handleDatatablesPagingRequest(dtPagingRequest);
         return ResponseEntity.ok()
-                .body(this.instanceDomainToDtoMapper.convertToDtPage(page, dtPagingRequest, InstanceDto.class));
+                .body(this.instanceDomainToDtDtoMapper.convertToDtPage(page, dtPagingRequest, InstanceDtDto.class));
     }
 
     /**

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/models/domain/Instance.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/models/domain/Instance.java
@@ -175,7 +175,7 @@ public class Instance implements Serializable, JsonSerializable {
     @JoinColumn(unique = true)
     private Xml instanceAsXml;
 
-    @OneToOne(cascade = {CascadeType.ALL}, orphanRemoval = true)
+    @OneToOne(cascade = {CascadeType.ALL}, orphanRemoval = true, fetch=FetchType.LAZY)
     @JoinColumn(unique = true)
     private Doc instanceAsDoc;
 

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/models/dto/InstanceDtDto.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/models/dto/InstanceDtDto.java
@@ -19,8 +19,6 @@ package net.maritimeconnectivity.serviceregistry.models.dto;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import net.maritimeconnectivity.serviceregistry.models.JsonSerializable;
-import net.maritimeconnectivity.serviceregistry.models.domain.Doc;
-import net.maritimeconnectivity.serviceregistry.models.domain.Xml;
 import net.maritimeconnectivity.serviceregistry.models.domain.enums.LedgerRequestStatus;
 import net.maritimeconnectivity.serviceregistry.utils.GeometryJSONDeserializer;
 import net.maritimeconnectivity.serviceregistry.utils.GeometryJSONSerializer;
@@ -35,11 +33,11 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * The Instance DTO Class.
+ * The Instance Datatables DTO Class.
  *
  * @author Nikolaos Vastardis (email: Nikolaos.Vastardis@gla-rad.org)
  */
-public class InstanceDto implements Serializable, JsonSerializable {
+public class InstanceDtDto implements Serializable, JsonSerializable {
 
     private static final long serialVersionUID = -1173956383783083179L;
 
@@ -69,8 +67,9 @@ public class InstanceDto implements Serializable, JsonSerializable {
     private String mmsi;
     private String imo;
     private String serviceType;
-    private Xml instanceAsXml;
-    private DocDto instanceAsDoc;
+    private XmlDto instanceAsXml;
+    private Long instanceAsDocId;
+    private String instanceAsDocName;
     private Long ledgerRequestId;
     private LedgerRequestStatus ledgerRequestStatus;
     private Set<Long> docIds = new HashSet<>();
@@ -80,7 +79,7 @@ public class InstanceDto implements Serializable, JsonSerializable {
     /**
      * Instantiates a new Instance dto.
      */
-    public InstanceDto() {
+    public InstanceDtDto() {
 
     }
 
@@ -413,7 +412,7 @@ public class InstanceDto implements Serializable, JsonSerializable {
      *
      * @return the instance as xml
      */
-    public Xml getInstanceAsXml() {
+    public XmlDto getInstanceAsXml() {
         return instanceAsXml;
     }
 
@@ -422,26 +421,44 @@ public class InstanceDto implements Serializable, JsonSerializable {
      *
      * @param instanceAsXml the instance as xml
      */
-    public void setInstanceAsXml(Xml instanceAsXml) {
+    public void setInstanceAsXml(XmlDto instanceAsXml) {
         this.instanceAsXml = instanceAsXml;
     }
 
     /**
-     * Gets instance as doc.
+     * Gets instance as doc id.
      *
-     * @return the instance as doc
+     * @return the instance as doc id
      */
-    public DocDto getInstanceAsDoc() {
-        return instanceAsDoc;
+    public Long getInstanceAsDocId() {
+        return instanceAsDocId;
     }
 
     /**
-     * Sets instance as doc.
+     * Sets instance as doc id.
      *
-     * @param instanceAsDoc the instance as doc
+     * @param instanceAsDocId the instance as doc id
      */
-    public void setInstanceAsDoc(DocDto instanceAsDoc) {
-        this.instanceAsDoc = instanceAsDoc;
+    public void setInstanceAsDocId(Long instanceAsDocId) {
+        this.instanceAsDocId = instanceAsDocId;
+    }
+
+    /**
+     * Gets instance as doc name.
+     *
+     * @return the instance as doc name
+     */
+    public String getInstanceAsDocName() {
+        return instanceAsDocName;
+    }
+
+    /**
+     * Sets instance as doc name.
+     *
+     * @param instanceAsDocName the instance as doc name
+     */
+    public void setInstanceAsDocName(String instanceAsDocName) {
+        this.instanceAsDocName = instanceAsDocName;
     }
 
     /**

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/utils/HeaderUtil.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/utils/HeaderUtil.java
@@ -20,6 +20,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 
+import java.util.Optional;
+
 /**
  * Utility class for HTTP headers creation.
  *
@@ -98,8 +100,12 @@ public class HeaderUtil {
     public static HttpHeaders createFailureAlert(String entityName, String errorKey, String defaultMessage) {
         log.error("Entity creation failed, {}", defaultMessage);
         HttpHeaders headers = new HttpHeaders();
-        headers.add("X-mcsrApp-error", "error." + errorKey);
-        headers.add("X-mcsrApp-params", entityName);
+        headers.add("X-mcsrApp-error", "error." + Optional.ofNullable(errorKey)
+                .map(e -> e.replaceAll("(\\r|\\n)", ""))
+                .orElse("Unknown Error"));
+        headers.add("X-mcsrApp-params", Optional.ofNullable(entityName)
+                .map(e -> e.replaceAll("(\\r|\\n)", ""))
+                .orElse("Unknown Entity"));
         return headers;
     }
 

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/utils/MsrErrorConstant.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/utils/MsrErrorConstant.java
@@ -17,8 +17,8 @@
 package net.maritimeconnectivity.serviceregistry.utils;
 
 public class MsrErrorConstant {
-    public static final String LEDGER_NOT_CONNECTED = "The MSR Ledger is not able to connect";
-    public static final String LEDGER_REQUEST_STATUS_NOT_FULFILLED = "MSR ledger request status should be set as 'VETTED'";
-    public static final String LEDGER_REQUEST_NOT_FOUND = "No ledger request is found";
-    public static final String LEDGER_REGISTRATION_FAILED = "Instance registration to the MSR ledger has failed";
+    public static final String LEDGER_NOT_CONNECTED = "Unable to connect to the MSR global ledger.";
+    public static final String LEDGER_REQUEST_STATUS_NOT_FULFILLED = "Registration to the global MSR ledger requires the request status to be set to 'VETTED'.";
+    public static final String LEDGER_REQUEST_NOT_FOUND = "No requested ledger request was not found.";
+    public static final String LEDGER_REGISTRATION_FAILED = "Instance registration to the MSR ledger has failed.";
 }

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/utils/MsrErrorConstant.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/utils/MsrErrorConstant.java
@@ -20,6 +20,5 @@ public class MsrErrorConstant {
     public static final String LEDGER_NOT_CONNECTED = "The MSR Ledger is not able to connect";
     public static final String LEDGER_REQUEST_STATUS_NOT_FULFILLED = "MSR ledger request status should be set as 'VETTED'";
     public static final String LEDGER_REQUEST_NOT_FOUND = "No ledger request is found";
-    public static final String LEDGER_REQUEST_INSTANCE_NOT_FOUND = "Instance corresponding to the request is not found";
     public static final String LEDGER_REGISTRATION_FAILED = "Instance registration to the MSR ledger has failed";
 }

--- a/src/main/resources/static/css/common.css
+++ b/src/main/resources/static/css/common.css
@@ -2,6 +2,31 @@ body {
     font-size: medium;
 }
 
+/* The Overlay (background) */
+.loader-overlay {
+    height: 100%;
+    width: 100%;
+    position: fixed; /* Stay in place */
+    z-index: 99999; /* Sit on top */
+    left: 0;
+    top: 0;
+    overflow-x: hidden; /* Disable horizontal scroll */
+}
+
+.loader-overlay-background {
+    height: 100%;
+    width: 100%;
+    background-color: rgba(0,0,0, 0.3); /* Black w/opacity */
+}
+
+.loader-overlay-spinner {
+    position: fixed;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+}
+
+/* The map search overlay card */
 .search-overlay {
     position: absolute;
     top: 80px;

--- a/src/main/resources/static/lib/dataTables.msrEditor.free.js
+++ b/src/main/resources/static/lib/dataTables.msrEditor.free.js
@@ -522,16 +522,16 @@
                             }
                         }
 
-                        data += "<div style='margin-left: initial; margin-right: initial;' class='form-group row'>"
-                            + "<label for='" + that._quoteattr(columnDefs[j].name) + "'>" + title + ":&nbsp</label>"
-                            + "<input type='hidden' "
+                        data += "<div style='margin-left: initial; margin-right: initial;' class='row'>"
+                            + "<div class='col-4'><label for='" + that._quoteattr(columnDefs[j].name) + "'>" + title + ":&nbsp</label></div>"
+                            + "<div class='col-8'><input type='hidden' "
                                 + "id='" + that._quoteattr(title) + "' "
                                 + "name='" + that._quoteattr(title) + "' "
                                 + "placeholder='" + that._quoteattr(title) + "' "
                                 + "style='overflow: hidden;' class='form-control' "
                                 + "value='" + that._quoteattr(fvalue) + "' >"
                                 + fvalue
-                            + "</input></div>";
+                            + "</input></div></div>";
                     }
                 }
 

--- a/src/main/resources/static/src/common.js
+++ b/src/main/resources/static/src/common.js
@@ -7,6 +7,15 @@ $(() => {
 });
 
 /**
+ * A helper function that parses the response's and and returns the value
+ * from the 'X-mcsrApp-error' header if it exists, or the selected default
+ * message if not.
+ */
+function getErrorFromHeader(response, defaultMessage) {
+    return response.getResponseHeader('X-mcsrApp-error') ? response.getResponseHeader('X-mcsrApp-error') : defaultMessage;
+}
+
+/**
  * A helper function that shows the error boostrap error dialog and displays
  * the provided error message in it.
  */

--- a/src/main/resources/static/src/common.js
+++ b/src/main/resources/static/src/common.js
@@ -7,6 +7,26 @@ $(() => {
 });
 
 /**
+ * A helper function that displays the loader spinner.
+ */
+function showLoader(overlay = true) {
+    if(!overlay) {
+        $('#pageLoaderBackground').hide();
+    } else {
+        $('#pageLoaderBackground').show();
+    }
+    $('#pageLoader').show();
+}
+
+/**
+ * A helper function that hides the loader spinner.
+ */
+function hideLoader() {
+
+    $('#pageLoader').hide();
+}
+
+/**
  * A helper function that parses the response's and and returns the value
  * from the 'X-mcsrApp-error' header if it exists, or the selected default
  * message if not.

--- a/src/main/resources/static/src/docs-api.js
+++ b/src/main/resources/static/src/docs-api.js
@@ -1,0 +1,35 @@
+/******************************************************************************
+ *                               DOCS API CALLS                               *
+ ******************************************************************************/
+class DocsApi {
+
+    /**
+     * The Docs API Class Constructor.
+     */
+    constructor() {
+
+    }
+
+    /**
+     * API Instance Doc reading function.
+     *
+     * @param  {number} docId           The ID of the doc to be retrieved
+     * @param  {Function} callback      The callback to be used after the AJAX call
+     * @param  {Function} errorCallback The error callback to be used if the AJAX call fails
+     */
+    getDoc(docId, callback, errorCallback) {
+        $.ajax({
+            url: `api/docs/${docId}`,
+            type: 'GET',
+            contentType: 'application/json',
+            success: callback,
+            error: (response, status, more) => {
+                if(errorCallback) {
+                    errorCallback(response, status, more);
+                } else {
+                    console.error(response)
+                }
+            }
+        });
+    }
+}

--- a/src/main/resources/static/src/file-utils.js
+++ b/src/main/resources/static/src/file-utils.js
@@ -1,0 +1,71 @@
+/******************************************************************************
+ *                               FILE UTILITIES                               *
+ ******************************************************************************/
+class FileUtils {
+
+    /**
+     * The FileUtils Class Constructor.
+     */
+    constructor() {
+
+    }
+
+    /**
+     * Opens the provided file data (based on its type) in a new browser window.
+     *
+     * @param {string}      type        The file type to be opened
+     * @param {string}      data        The Base64 encoded data
+     */
+    openFileWindow(type, data) {
+        window.open('data:' + type + ';base64,' + data, '_blank', 'height=800,width=900');
+    }
+
+    /**
+     * Encodes the provided file into a Base64 string and returns it using the
+     * provided callback.
+     *
+     * @param {file}        file        The file to be encoded
+     * @param {Function}    callback    The callback function to return the encoded file
+     */
+    encodeFileToBase64(file, callback) {
+        var fileReader = new FileReader();
+        fileReader.onload = function (e) {
+            var base64Data = e.target.result.substr(e.target.result.indexOf('base64,') + 'base64,'.length);
+            callback(base64Data);
+        };
+        fileReader.readAsDataURL(file);
+    }
+
+    /**
+     * Opens a download dialogs for saving the provided file data into a local
+     * file.
+     *
+     * @param {string}      filename    The name of the file to be saved
+     * @param {string}      type        The file type to be saved
+     * @param {string}      data        The Base64 encoded data
+     */
+    downloadFile(filename, type, data) {
+        // decode base64 string, remove space for IE compatibility
+        var binary = atob(data.replace(/\s/g, ''));
+        var len = binary.length;
+        var buffer = new ArrayBuffer(len);
+        var view = new Uint8Array(buffer);
+        for (var i = 0; i < len; i++) {
+            view[i] = binary.charCodeAt(i);
+        }
+
+        var blob = new Blob([view], {type: type});
+        if(window.navigator.msSaveOrOpenBlob) {
+            window.navigator.msSaveBlob(blob, filename);
+        }
+        else {
+            var elem = window.document.createElement('a');
+            elem.href = window.URL.createObjectURL(blob);
+            elem.download = filename;
+            document.body.appendChild(elem);
+            elem.click();
+            document.body.removeChild(elem);
+        }
+    }
+}
+/******************************************************************************/

--- a/src/main/resources/static/src/instances-api.js
+++ b/src/main/resources/static/src/instances-api.js
@@ -1,0 +1,129 @@
+/******************************************************************************
+ *                            INSTANCES API CALLS                             *
+ ******************************************************************************/
+class InstancesApi {
+
+    /**
+     * The Instances API Class Constructor.
+     */
+    constructor() {
+
+    }
+
+    /**
+     * API instance creation function.
+     *
+     * @param  {obj} instance           The instance to be created
+     * @param  {Function} callback      The callback to be used after the AJAX call
+     * @param  {Function} errorCallback The error callback to be used if the AJAX call fails
+     */
+    createInstance(instance, callback, errorCallback) {
+        $.ajax({
+            url: '/api/instances',
+            type: 'POST',
+            contentType: 'application/json',
+            dataType: 'json',
+            data: instance,
+            success: callback,
+            error: errorCallback
+        });
+    }
+
+    /**
+     * API instance update function.
+     *
+     * @param  {int} id                 The ID of the instance to be updated
+     * @param  {obj} instance           The instance to be created
+     * @param  {Function} callback      The callback to be used after the AJAX call
+     * @param  {Function} errorCallback The error callback to be used if the AJAX call fails
+     */
+    updateInstance(id, instance, callback, errorCallback) {
+        $.ajax({
+            url: `/api/instances/${id}`,
+            type: 'PUT',
+            contentType: 'application/json',
+            dataType: 'json',
+            data: instance,
+            success: callback,
+            error:  (response, status, more) => {
+                if(errorCallback) {
+                    errorCallback(response, status, more);
+                } else {
+                    console.error(response)
+                }
+            }
+        });
+    }
+
+    /**
+     * API instance deletion function.
+     *
+     * @param  {int} id                 The ID of the instance to be deleted
+     * @param  {Function} callback      The callback to be used after the AJAX call
+     * @param  {Function} errorCallback The error callback to be used if the AJAX call fails
+     */
+    deleteInstance(id, callback, errorCallback) {
+        $.ajax({
+            url: `/api/instances/${id}`,
+            type: 'DELETE',
+            contentType: 'application/json',
+            success: callback,
+            error:  (response, status, more) => {
+                if(errorCallback) {
+                    errorCallback(response, status, more);
+                } else {
+                    console.error(response)
+                }
+           }
+        });
+    }
+
+    /**
+     * API setter function for the instance status.
+     *
+     * @param  {int} id                 The ID of the instance to be updated
+     * @param  {string} status          The status to update the instance with
+     * @param  {Function} callback      The callback to be used after the AJAX call
+     * @param  {Function} errorCallback The error callback to be used if the AJAX call fails
+     */
+    setStatus(id, status, callback, errorCallback) {
+        $.ajax({
+            url: `/api/instances/${id}/status?status=${status}`,
+            type: 'PUT',
+            contentType: 'application/json',
+            success: callback,
+            error: (response, status, more) => {
+                if(errorCallback) {
+                    errorCallback(response, status, more);
+                } else {
+                    console.error(response)
+                }
+            }
+        });
+    }
+
+    /**
+      * API setter function for the instance global ledger status.
+      *
+      * @param  {int} id                The ID of the instance to be updated
+      * @param  {string} status         The global ledger status to update the instance with
+      * @param  {Function} callback     The callback to be used after the AJAX call
+      * @param  {Function} errorCallback The error callback to be used if the AJAX call fails
+      */
+    setLedgerStatus(id, status, callback, errorCallback) {
+        $.ajax({
+            url: `/api/instances/${id}/ledger-status?ledgerStatus=${status}`,
+            type: 'PUT',
+            contentType: 'application/json',
+            success: callback,
+            error: (response, status, more) => {
+                if(errorCallback) {
+                    errorCallback(response, status, more);
+                } else {
+                    console.error(response)
+                }
+            }
+        });
+    }
+}
+/******************************************************************************/

--- a/src/main/resources/static/src/instances-api.js
+++ b/src/main/resources/static/src/instances-api.js
@@ -25,7 +25,13 @@ class InstancesApi {
             dataType: 'json',
             data: instance,
             success: callback,
-            error: errorCallback
+            error: (response, status, more) => {
+               if(errorCallback) {
+                   errorCallback(response, status, more);
+               } else {
+                   console.error(response)
+               }
+           }
         });
     }
 

--- a/src/main/resources/static/src/ledger-requests-api.js
+++ b/src/main/resources/static/src/ledger-requests-api.js
@@ -1,0 +1,36 @@
+/******************************************************************************
+ *                         LEDGER REQUESTS API CALLS                          *
+ ******************************************************************************/
+class LedgerRequestsApi {
+
+    /**
+     * The Ledger Requests API Class Constructor.
+     */
+    constructor() {
+
+    }
+
+    /**
+     * API getter function for a single ledger request by ID.
+     *
+     * @param  {int} id                 The ID of the ledger request to be retrieved
+     * @param  {Function} callback      The callback to be used after the AJAX call
+     * @param  {Function} errorCallback The error callback to be used if the AJAX call fails
+     */
+    getLedgerRequest(id, status, callback, errorCallback) {
+        $.ajax({
+            url: `/api/ledgerrequests/${id}`,
+            type: 'GET',
+            contentType: 'application/json',
+            success: callback,
+            error: (response, status, more) => {
+                if(errorCallback) {
+                    errorCallback(response, status, more);
+                } else {
+                    console.error(response)
+                }
+            }
+        });
+    }
+}
+/******************************************************************************/

--- a/src/main/resources/static/src/xmls-api.js
+++ b/src/main/resources/static/src/xmls-api.js
@@ -1,0 +1,56 @@
+/******************************************************************************
+ *                               XMLS API CALLS                               *
+ ******************************************************************************/
+class XmlsApi {
+
+    /**
+     * The XMLs API Class Constructor.
+     */
+    constructor() {
+
+    }
+
+    /**
+     * API Instance XML validation function.
+     *
+     * @param  {string} xml             The XML input to be validated
+     * @param  {Function} callback      The callback to be used after the AJAX call
+     * @param  {Function} errorCallback The error callback to be used if the AJAX call fails
+     */
+    validateInstanceXml(xml, callback, errorCallback) {
+        $.ajax({
+            url: `api/xmls/validate/INSTANCE`,
+            type: 'POST',
+            contentType: 'application/xml',
+            dataType: 'json',
+            data: xml,
+            success: (response, status, more) => {
+                var instance = {};
+                for (var field in response) {
+                    var name = field;
+                    var value = response[name];
+                    // Translate the G1128 field names to the current model
+                    if (name == 'id')
+                       name = 'instanceId';
+                    else if(name == 'description')
+                       name = 'comment';
+                    else if(name == 'endpoint')
+                       name = 'endpointUri';
+                    else if(name == 'implementsServiceDesign') {
+                       name = 'designs';
+                       value = value['id'];
+                    }
+                    instance[name] = value
+                }
+                callback(instance, callback, errorCallback)
+            },
+            error: (response, status, more) => {
+                if(errorCallback) {
+                    errorCallback(response, status, more);
+                } else {
+                    console.error(response)
+                }
+            }
+        });
+    }
+}

--- a/src/main/resources/static/src/xmls-api.js
+++ b/src/main/resources/static/src/xmls-api.js
@@ -9,6 +9,29 @@ class XmlsApi {
     constructor() {
 
     }
+    
+    /**
+     * API Instance XML reading function.
+     *
+     * @param  {number} xmlId           The ID of the xml to be retrieved
+     * @param  {Function} callback      The callback to be used after the AJAX call
+     * @param  {Function} errorCallback The error callback to be used if the AJAX call fails
+     */
+    getXml(xmlId, callback, errorCallback) {
+        $.ajax({
+            url: `api/xmls/${xmlId}`,
+            type: 'GET',
+            contentType: 'application/json',
+            success: callback,
+            error: (response, status, more) => {
+                if(errorCallback) {
+                    errorCallback(response, status, more);
+                } else {
+                    console.error(response)
+                }
+            }
+        });
+    }
 
     /**
      * API Instance XML validation function.
@@ -42,7 +65,7 @@ class XmlsApi {
                     }
                     instance[name] = value
                 }
-                callback(instance, callback, errorCallback)
+                callback(instance)
             },
             error: (response, status, more) => {
                 if(errorCallback) {

--- a/src/main/resources/templates/fragments/general.html
+++ b/src/main/resources/templates/fragments/general.html
@@ -146,5 +146,13 @@
             </div>
         </footer>
     </div>
+    <div th:fragment="loader" id="pageLoader" class="loader-overlay">
+        <div id="pageLoaderBackground" class="loader-overlay-background"></div>
+        <div id="pageLoaderSpinner" class="loader-overlay-spinner">
+            <div class="spinner-border text-dark" role="status" style="width: 5rem; height: 5rem;">
+                <span class="visually-hidden">Loading...</span>
+            </div>
+        </div>
+    </div>
 </body>
 </html>

--- a/src/main/resources/templates/instances.html
+++ b/src/main/resources/templates/instances.html
@@ -260,6 +260,16 @@
                                                style="overflow:hidden;">
                                     </div>
                                 </div>
+                                <div style="margin-left: initial;margin-right: initial;"
+                                     class="form-group row"
+                                     id="editor-row-files">
+                                    <div class="col-sm-3 col-md-3 col-lg-3 text-right"
+                                         style="padding-top:4px;">
+                                        <label for="docs" class="col-form-label col-form-label-sm">Docs:</label></div>
+                                    <div class="col-sm-8 col-md-8 col-lg-8">
+                                        <input class="form-control form-control-sm" type="file" id="docs" multiple />
+                                    </div>
+                                </div>
                             </div>
                         </div>
                         </form>
@@ -398,6 +408,9 @@
     <script src="https://cdn.datatables.net/responsive/2.2.5/js/dataTables.responsive.js" ></script>
     <script th:src="@{/static/lib/dataTables.msrEditor.free.js}"></script>
     <script th:src="@{/static/src/common.js}"></script>
+    <script th:src="@{/static/src/instances-api.js}"></script>
+    <script th:src="@{/static/src/xmls-api.js}"></script>
+    <script th:src="@{/static/src/ledger-requests-api.js}"></script>
     <script th:src="@{/static/src/instances.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/instances.html
+++ b/src/main/resources/templates/instances.html
@@ -28,6 +28,7 @@
         <div th:replace="fragments/general.html :: navbar"></div>
         <div class="flex-fill flex-grow-1 flex-shrink-0">
             <div id="main-content" class="container-fluid mt-3">
+                <div th:replace="fragments/general.html :: loader"></div>
                 <div th:replace="fragments/general.html :: login-card"></div>
                 <div class="card shadow" sec:authorize="isAuthenticated()">
                     <div class="card-header">
@@ -265,9 +266,18 @@
                                      id="editor-row-files">
                                     <div class="col-sm-3 col-md-3 col-lg-3 text-right"
                                          style="padding-top:4px;">
-                                        <label for="docs" class="col-form-label col-form-label-sm">Docs:</label></div>
+                                        <label for="instanceAsDoc" class="col-form-label col-form-label-sm">Instance Doc:</label></div>
                                     <div class="col-sm-8 col-md-8 col-lg-8">
-                                        <input class="form-control form-control-sm" type="file" id="docs" multiple />
+                                        <input class="form-control form-control-sm" type="file" id="instanceAsDoc" style="display: none;"/>
+                                        <div class="input-group" id="instanceAsDocWithValue">
+                                            <input class="form-control form-control-sm" type="text" id="instanceAsDocName" disabled/>
+                                            <button class="btn btn-secondary btn-sm btn-clear-instance-doc" type="button">
+                                                <i class="fas fa-trash-alt"></i>
+                                            </button>
+                                            <button class="btn btn-secondary btn-sm btn-download-instance-doc" type="button">
+                                                <i class="fas fa-download"></i>
+                                            </button>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -408,8 +418,10 @@
     <script src="https://cdn.datatables.net/responsive/2.2.5/js/dataTables.responsive.js" ></script>
     <script th:src="@{/static/lib/dataTables.msrEditor.free.js}"></script>
     <script th:src="@{/static/src/common.js}"></script>
+    <script th:src="@{/static/src/file-utils.js}"></script>
     <script th:src="@{/static/src/instances-api.js}"></script>
     <script th:src="@{/static/src/xmls-api.js}"></script>
+    <script th:src="@{/static/src/docs-api.js}"></script>
     <script th:src="@{/static/src/ledger-requests-api.js}"></script>
     <script th:src="@{/static/src/instances.js}"></script>
 </body>

--- a/src/test/java/net/maritimeconnectivity/serviceregistry/TestingConfiguration.java
+++ b/src/test/java/net/maritimeconnectivity/serviceregistry/TestingConfiguration.java
@@ -22,6 +22,7 @@ import net.maritimeconnectivity.serviceregistry.models.domain.Doc;
 import net.maritimeconnectivity.serviceregistry.models.domain.Instance;
 import net.maritimeconnectivity.serviceregistry.models.domain.Xml;
 import net.maritimeconnectivity.serviceregistry.models.dto.DocDto;
+import net.maritimeconnectivity.serviceregistry.models.dto.InstanceDtDto;
 import net.maritimeconnectivity.serviceregistry.models.dto.InstanceDto;
 import net.maritimeconnectivity.serviceregistry.models.dto.XmlDto;
 import org.modelmapper.ModelMapper;
@@ -55,6 +56,14 @@ public class TestingConfiguration {
     @Bean
     public DomainDtoMapper instanceDomainToDtoMapper() {
         return new DomainDtoMapper<Instance, InstanceDto>();
+    }
+
+    /**
+     * Instance Mapper from Domain to Datatable DTO.
+     */
+    @Bean
+    public DomainDtoMapper instanceDomainToDtDtoMapper() {
+        return new DomainDtoMapper<Instance, InstanceDtDto>();
     }
 
     /**

--- a/src/test/java/net/maritimeconnectivity/serviceregistry/services/InstanceServiceTest.java
+++ b/src/test/java/net/maritimeconnectivity/serviceregistry/services/InstanceServiceTest.java
@@ -344,7 +344,7 @@ class InstanceServiceTest {
      * Test that we can successfully delete an existing instance.
      */
     @Test
-    void testDelete() throws DataNotFoundException {
+    void testDelete() {
         doReturn(Optional.of(this.existingInstance)).when(this.instanceRepo).findById(this.existingInstance.getId());
         doNothing().when(this.ledgerRequestService).deleteByInstanceId(this.existingInstance.getId());
         doNothing().when(this.instanceRepo).deleteById(this.existingInstance.getId());

--- a/src/test/java/net/maritimeconnectivity/serviceregistry/services/LedgerRequestServiceTest.java
+++ b/src/test/java/net/maritimeconnectivity/serviceregistry/services/LedgerRequestServiceTest.java
@@ -19,10 +19,12 @@ package net.maritimeconnectivity.serviceregistry.services;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import net.maritimeconnectivity.serviceregistry.components.SmartContractProvider;
 import net.maritimeconnectivity.serviceregistry.exceptions.DataNotFoundException;
+import net.maritimeconnectivity.serviceregistry.exceptions.LedgerRegistrationError;
 import net.maritimeconnectivity.serviceregistry.models.domain.Instance;
 import net.maritimeconnectivity.serviceregistry.models.domain.LedgerRequest;
 import net.maritimeconnectivity.serviceregistry.models.domain.enums.LedgerRequestStatus;
 import net.maritimeconnectivity.serviceregistry.repos.LedgerRequestRepo;
+import net.maritimeconnectivity.serviceregistry.utils.MsrContract;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,10 +36,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.web3j.protocol.core.RemoteFunctionCall;
+import org.web3j.protocol.core.methods.response.TransactionReceipt;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -76,6 +82,13 @@ class LedgerRequestServiceTest {
     private Instance instance;
     private LedgerRequest newLedgerRequest;
     private LedgerRequest existingLedgerRequest;
+    private MsrContract msrContract;
+
+    // The We3j transaction calls
+    private RemoteFunctionCall remoteFunctionCall;
+    private CompletableFuture completableFuture;
+    private CompletableFuture completableFutureWithEx;
+    private TransactionReceipt transactionReceipt;
 
     /**
      * Common setup for all the tests.
@@ -108,6 +121,7 @@ class LedgerRequestServiceTest {
 
         // Create an instance to link to the ledger requests
         this.instance = new Instance();
+        this.instance.setName("Test Instance");
         this.instance.setId(123456L);
         this.instance.setVersion("1.0.0");
         this.instance.setInstanceId(String.format("net.maritimeconnectivity.service-registry.instance.%d", instance.getId()));
@@ -116,8 +130,6 @@ class LedgerRequestServiceTest {
         this.newLedgerRequest = new LedgerRequest();
         this.newLedgerRequest.setStatus(LedgerRequestStatus.CREATED);
         this.newLedgerRequest.setReason("Some reason");
-        this.newLedgerRequest.setLastUpdatedAt("02/01/2001");
-        this.newLedgerRequest.setCreatedAt("01/01/2001");
         this.newLedgerRequest.setServiceInstance(instance);
 
         // Create an existing ledger request
@@ -128,6 +140,19 @@ class LedgerRequestServiceTest {
         this.existingLedgerRequest.setLastUpdatedAt("02/01/2001");
         this.existingLedgerRequest.setCreatedAt("01/01/2001");
         this.existingLedgerRequest.setServiceInstance(instance);
+
+        // Mock an MSR smart contract
+        this.msrContract = mock(MsrContract.class);
+
+        // Mock the Web3j remove function call and response
+        this.remoteFunctionCall = mock(RemoteFunctionCall.class);
+        this.transactionReceipt = mock(TransactionReceipt.class);
+
+        // Create a couple of completable future tasks to mimic the ledger response
+        this.completableFuture = new CompletableFuture<>();
+        Executors.newCachedThreadPool().submit(() -> completableFuture.complete(this.transactionReceipt));
+        this.completableFutureWithEx = new CompletableFuture<>();
+        Executors.newCachedThreadPool().submit(() -> completableFutureWithEx.completeExceptionally(new RuntimeException("Something went wrong")));
     }
 
     /**
@@ -163,7 +188,7 @@ class LedgerRequestServiceTest {
         // Perform the service call
         LedgerRequest result = this.ledgerRequestService.findOne(this.existingLedgerRequest.getId());
 
-        // Make sure the eager relationships repo call was called
+        // Make sure the eager relationships' repo call was called
         verify(this.ledgerRequestRepo, times(1)).findById(this.existingLedgerRequest.getId());
 
         // Test the result
@@ -190,4 +215,400 @@ class LedgerRequestServiceTest {
         );
     }
 
+    /**
+     * Test that we can retrieve a single ledger request entry based on the
+     * ledger request instance ID and all the eager relationships are loaded.
+     */
+    @Test
+    void testFindByInstanceId() {
+        doReturn(Optional.of(this.existingLedgerRequest)).when(this.ledgerRequestRepo).findByInstanceId(this.existingLedgerRequest.getServiceInstance().getId());
+
+        // Perform the service call
+        LedgerRequest result = this.ledgerRequestService.findByInstanceId(this.existingLedgerRequest.getServiceInstance().getId());
+
+        // Make sure the eager relationships' repo call was called
+        verify(this.ledgerRequestRepo, times(1)).findByInstanceId(this.existingLedgerRequest.getServiceInstance().getId());
+
+        // Test the result
+        assertNotNull(result);
+        assertEquals(this.existingLedgerRequest.getId(), result.getId());
+        assertEquals(this.existingLedgerRequest.getStatus(), result.getStatus());
+        assertEquals(this.existingLedgerRequest.getReason(), result.getReason());
+        assertEquals(this.existingLedgerRequest.getLastUpdatedAt(), result.getLastUpdatedAt());
+        assertEquals(this.existingLedgerRequest.getCreatedAt(), result.getCreatedAt());
+        assertEquals(this.existingLedgerRequest.getServiceInstance().getId(), result.getServiceInstance().getId());
+    }
+
+    /**
+     * Test that if we do not find the ledger request by the instance ID, a
+     * DataNotFoundException will be thrown.
+     */
+    @Test
+    void testFindByInstanceIdNotFound() {
+        doReturn(Optional.empty()).when(this.ledgerRequestRepo).findByInstanceId(this.existingLedgerRequest.getServiceInstance().getId());
+
+        // Perform the service call
+        assertThrows(DataNotFoundException.class, () ->
+                this.ledgerRequestService.findByInstanceId(this.existingLedgerRequest.getServiceInstance().getId())
+        );
+    }
+
+    /**
+     * Test that we can correctly save a new ledger request when the provided
+     * information is valid.
+     */
+    @Test
+    void testSaveNew() {
+        doReturn(this.instance).when(this.instanceService).findOne(this.newLedgerRequest.getServiceInstance().getId());
+        doReturn(this.existingLedgerRequest).when(this.ledgerRequestRepo).save(this.newLedgerRequest);
+
+        // Perform the service call
+        LedgerRequest result = this.ledgerRequestService.save(this.newLedgerRequest);
+
+        // Test the result
+        assertNotNull(result);
+        assertEquals(this.existingLedgerRequest.getId(), result.getId());
+        assertEquals(this.existingLedgerRequest.getStatus(), result.getStatus());
+        assertEquals(this.existingLedgerRequest.getReason(), result.getReason());
+        assertEquals(this.existingLedgerRequest.getLastUpdatedAt(), result.getLastUpdatedAt());
+        assertEquals(this.existingLedgerRequest.getCreatedAt(), result.getCreatedAt());
+        assertEquals(this.existingLedgerRequest.getServiceInstance().getId(), result.getServiceInstance().getId());
+    }
+
+    /**
+     * Test that we can correctly save a new ledger request when the provided
+     * information is valid.
+     */
+    @Test
+    void testSaveExisting() {
+        doReturn(Boolean.TRUE).when(this.ledgerRequestRepo).existsById(this.existingLedgerRequest.getId());
+        doReturn(this.instance).when(this.instanceService).findOne(this.existingLedgerRequest.getServiceInstance().getId());
+        doReturn(this.existingLedgerRequest).when(this.ledgerRequestRepo).save(this.existingLedgerRequest);
+
+        // Perform the service call
+        LedgerRequest result = this.ledgerRequestService.save(this.existingLedgerRequest);
+
+        // Test the result
+        assertNotNull(result);
+        assertEquals(this.existingLedgerRequest.getId(), result.getId());
+        assertEquals(this.existingLedgerRequest.getStatus(), result.getStatus());
+        assertEquals(this.existingLedgerRequest.getReason(), result.getReason());
+        assertEquals(this.existingLedgerRequest.getLastUpdatedAt(), result.getLastUpdatedAt());
+        assertEquals(this.existingLedgerRequest.getCreatedAt(), result.getCreatedAt());
+        assertEquals(this.existingLedgerRequest.getServiceInstance().getId(), result.getServiceInstance().getId());
+    }
+
+    /**
+     * Test that if we are trying to save an existing ledger request with an
+     * invalid ID, a DataNotFoundException will be thrown.
+     */
+    @Test
+    void testSaveNoValidId() {
+        doReturn(Boolean.FALSE).when(this.ledgerRequestRepo).existsById(this.existingLedgerRequest.getId());
+
+        // Perform the service call
+        assertThrows(DataNotFoundException.class, () ->
+                this.ledgerRequestService.save(this.existingLedgerRequest)
+        );
+    }
+
+    /**
+     * Test that if we are trying to save an existing ledger request with an
+     * invalid instance ID, a DataNotFoundException will be thrown.
+     */
+    @Test
+    void testSaveNoValidInstanceId() {
+        doReturn(Boolean.TRUE).when(this.ledgerRequestRepo).existsById(this.existingLedgerRequest.getId());
+
+        // Perform the service call
+        assertThrows(DataNotFoundException.class, () ->
+                this.ledgerRequestService.save(this.existingLedgerRequest)
+        );
+    }
+
+    /**
+     * Test that we can successfully delete an existing ledger request.
+     */
+    @Test
+    void testDelete() throws DataNotFoundException {
+        doReturn(Boolean.TRUE).when(this.ledgerRequestRepo).existsById(this.existingLedgerRequest.getId());
+
+        // Perform the service call
+        this.ledgerRequestService.delete(this.existingLedgerRequest.getId());
+
+        // Verify that a deletion call took place in the repository
+        verify(this.ledgerRequestRepo, times(1)).deleteById(this.existingLedgerRequest.getId());
+    }
+
+    /**
+     * Test that if we try to delete a non-existing ledger request, then a
+     * DataNotFoundException will be thrown.
+     */
+    @Test
+    void testDeleteNotFound() {
+        doReturn(Boolean.FALSE).when(this.ledgerRequestRepo).existsById(this.existingLedgerRequest.getId());
+
+        // Perform the service call
+        assertThrows(DataNotFoundException.class, () ->
+                this.ledgerRequestService.delete(this.existingLedgerRequest.getId())
+        );
+    }
+
+    /**
+     * Test that we can successfully delete an existing ledger request by its
+     * instance ID.
+     */
+    @Test
+    void testDeleteByInstanceId() {
+        doReturn(this.existingLedgerRequest).when(this.ledgerRequestService).findByInstanceId(this.existingLedgerRequest.getServiceInstance().getId());
+        doReturn(Boolean.TRUE).when(this.ledgerRequestRepo).existsById(this.existingLedgerRequest.getId());
+
+        // Perform the service call
+        this.ledgerRequestService.deleteByInstanceId(this.existingLedgerRequest.getServiceInstance().getId());
+
+        // Verify that a deletion call took place in the repository
+        verify(this.ledgerRequestRepo, times(1)).deleteById(this.existingLedgerRequest.getId());
+    }
+
+    /**
+     * Test that if we try to delete a non-existing ledger request by its
+     * instance ID, then a DataNotFoundException will be thrown.
+     */
+    @Test
+    void testDeleteByInstanceIdNotFound() {
+        // Perform the service call
+        assertThrows(DataNotFoundException.class, () ->
+                this.ledgerRequestService.deleteByInstanceId(this.existingLedgerRequest.getServiceInstance().getId())
+        );
+    }
+
+    /**
+     * Test that we can update the ledger status of a ledger request, at least
+     * for all the non-restricted values.
+     */
+    @Test
+    void testStatusUpdate() {
+        // Create a ledger request with the updated status
+        LedgerRequest savedLedgerRequest = new LedgerRequest();
+        savedLedgerRequest.setId(this.existingLedgerRequest.getId());
+        savedLedgerRequest.setStatus(LedgerRequestStatus.VETTED);
+        savedLedgerRequest.setReason("Testing the status update");
+        savedLedgerRequest.setLastUpdatedAt(this.existingLedgerRequest.getLastUpdatedAt());
+        savedLedgerRequest.setCreatedAt(this.existingLedgerRequest.getCreatedAt());
+        savedLedgerRequest.setServiceInstance(this.existingLedgerRequest.getServiceInstance());
+
+        doReturn(Optional.of(this.existingLedgerRequest)).when(this.ledgerRequestRepo).findById(this.existingLedgerRequest.getId());
+        doReturn(Boolean.TRUE).when(this.ledgerRequestRepo).existsById(this.existingLedgerRequest.getId());
+        doReturn(this.instance).when(this.instanceService).findOne(this.existingLedgerRequest.getServiceInstance().getId());
+        doReturn(savedLedgerRequest).when(this.ledgerRequestRepo).save(this.existingLedgerRequest);
+
+        // Perform the service call
+        LedgerRequest result = this.ledgerRequestService.updateStatus(savedLedgerRequest.getId(), savedLedgerRequest.getStatus());
+
+        // Test the result
+        assertNotNull(result);
+        assertEquals(savedLedgerRequest.getId(), result.getId());
+        assertEquals(savedLedgerRequest.getStatus(), result.getStatus());
+        assertEquals(savedLedgerRequest.getReason(), result.getReason());
+        assertEquals(savedLedgerRequest.getLastUpdatedAt(), result.getLastUpdatedAt());
+        assertEquals(savedLedgerRequest.getCreatedAt(), result.getCreatedAt());
+        assertEquals(savedLedgerRequest.getServiceInstance().getId(), result.getServiceInstance().getId());
+    }
+
+    /**
+     * Test that we can update the ledger status of a ledger request with a
+     * reason explanation as well, at least for all the non-restricted values.
+     */
+    @Test
+    void testStatusUpdateWithReason() {
+        // Create a ledger request with the updated status
+        LedgerRequest savedLedgerRequest = new LedgerRequest();
+        savedLedgerRequest.setId(this.existingLedgerRequest.getId());
+        savedLedgerRequest.setStatus(LedgerRequestStatus.VETTED);
+        savedLedgerRequest.setReason("Testing the status update");
+        savedLedgerRequest.setLastUpdatedAt(this.existingLedgerRequest.getLastUpdatedAt());
+        savedLedgerRequest.setCreatedAt(this.existingLedgerRequest.getCreatedAt());
+        savedLedgerRequest.setServiceInstance(this.existingLedgerRequest.getServiceInstance());
+
+        doReturn(Optional.of(this.existingLedgerRequest)).when(this.ledgerRequestRepo).findById(this.existingLedgerRequest.getId());
+        doReturn(Boolean.TRUE).when(this.ledgerRequestRepo).existsById(this.existingLedgerRequest.getId());
+        doReturn(this.instance).when(this.instanceService).findOne(this.existingLedgerRequest.getServiceInstance().getId());
+        doReturn(savedLedgerRequest).when(this.ledgerRequestRepo).save(this.existingLedgerRequest);
+
+        // Perform the service call
+        LedgerRequest result = this.ledgerRequestService.updateStatus(savedLedgerRequest.getId(), savedLedgerRequest.getStatus(), savedLedgerRequest.getReason());
+
+        // Test the result
+        assertNotNull(result);
+        assertEquals(savedLedgerRequest.getId(), result.getId());
+        assertEquals(savedLedgerRequest.getStatus(), result.getStatus());
+        assertEquals(savedLedgerRequest.getReason(), result.getReason());
+        assertEquals(savedLedgerRequest.getLastUpdatedAt(), result.getLastUpdatedAt());
+        assertEquals(savedLedgerRequest.getCreatedAt(), result.getCreatedAt());
+        assertEquals(savedLedgerRequest.getServiceInstance().getId(), result.getServiceInstance().getId());
+    }
+
+    /**
+     * Test that we do not allow updates of restricted ledger status values
+     * directly from all publicly available class functions.
+     */
+    @Test
+    void testStatusUpdateRestricted() {
+        // Create a ledger request with the updated status
+        LedgerRequest savedLedgerRequest = new LedgerRequest();
+        savedLedgerRequest.setId(this.existingLedgerRequest.getId());
+        savedLedgerRequest.setStatus(LedgerRequestStatus.REQUESTING);
+        savedLedgerRequest.setReason("Testing the status update");
+        savedLedgerRequest.setLastUpdatedAt(this.existingLedgerRequest.getLastUpdatedAt());
+        savedLedgerRequest.setCreatedAt(this.existingLedgerRequest.getCreatedAt());
+        savedLedgerRequest.setServiceInstance(this.existingLedgerRequest.getServiceInstance());
+
+        doReturn(Optional.of(this.existingLedgerRequest)).when(this.ledgerRequestRepo).findById(this.existingLedgerRequest.getId());
+        doReturn(this.msrContract).when(this.smartContractProvider).getMsrContract();
+
+        // Perform the service calls
+        assertThrows(LedgerRegistrationError.class, () ->
+                this.ledgerRequestService.updateStatus(savedLedgerRequest.getId(), savedLedgerRequest.getStatus())
+        );
+        assertThrows(LedgerRegistrationError.class, () ->
+                this.ledgerRequestService.updateStatus(savedLedgerRequest.getId(), savedLedgerRequest.getStatus(), savedLedgerRequest.getReason())
+        );
+    }
+
+    /**
+     * Test that internally we can try to update the ledger status of a ledger
+     * request with a restricted status value.
+     */
+    @Test
+    void testStatusUpdateForce() {
+        // Create a ledger request with the updated status
+        LedgerRequest savedLedgerRequest = new LedgerRequest();
+        savedLedgerRequest.setId(this.existingLedgerRequest.getId());
+        savedLedgerRequest.setStatus(LedgerRequestStatus.REQUESTING);
+        savedLedgerRequest.setReason("Testing the status update");
+        savedLedgerRequest.setLastUpdatedAt(this.existingLedgerRequest.getLastUpdatedAt());
+        savedLedgerRequest.setCreatedAt(this.existingLedgerRequest.getCreatedAt());
+        savedLedgerRequest.setServiceInstance(this.existingLedgerRequest.getServiceInstance());
+
+        doReturn(Optional.of(this.existingLedgerRequest)).when(this.ledgerRequestRepo).findById(this.existingLedgerRequest.getId());
+
+        // Perform the service call
+        assertThrows(DataNotFoundException.class, () ->
+                this.ledgerRequestService.updateStatus(savedLedgerRequest.getId(), savedLedgerRequest.getStatus(), savedLedgerRequest.getReason(), true)
+        );
+    }
+
+    /**
+     * Test that if we try to update the ledger status of a ledger request with
+     * an invalid ledger request ID, a DataNotFoundException will be thrown.
+     */
+    @Test
+    void testStatusUpdateNoValidId() {
+        // Create a ledger request with the updated status
+        LedgerRequest savedLedgerRequest = new LedgerRequest();
+        savedLedgerRequest.setId(this.existingLedgerRequest.getId());
+        savedLedgerRequest.setStatus(LedgerRequestStatus.VETTED);
+        savedLedgerRequest.setReason("Testing the status update");
+        savedLedgerRequest.setLastUpdatedAt(this.existingLedgerRequest.getLastUpdatedAt());
+        savedLedgerRequest.setCreatedAt(this.existingLedgerRequest.getCreatedAt());
+        savedLedgerRequest.setServiceInstance(this.existingLedgerRequest.getServiceInstance());
+
+        // Perform the service call
+        assertThrows(DataNotFoundException.class, () ->
+                this.ledgerRequestService.updateStatus(this.existingLedgerRequest.getId(), this.newLedgerRequest.getStatus(), this.newLedgerRequest.getReason(), false)
+        );
+    }
+
+    /**
+     * Test that we can successfully register an instance to the ledger and
+     * the response will distance the new ledger request status.
+     */
+    @Test
+    void testRegisterInstanceToLedger() {
+        // Set the status to REQUESTING
+        this.existingLedgerRequest.setStatus(LedgerRequestStatus.VETTED);
+
+        doReturn(this.msrContract).when(this.smartContractProvider).getMsrContract();
+        doReturn(this.existingLedgerRequest).when(this.ledgerRequestService).findOne(this.existingLedgerRequest.getId());
+        doReturn(Boolean.TRUE).when(this.ledgerRequestRepo).existsById(this.existingLedgerRequest.getId());
+        doReturn(Optional.of(this.existingLedgerRequest)).when(this.ledgerRequestRepo).findById(this.existingLedgerRequest.getId());
+        doReturn(this.instance).when(this.instanceService).findOne(this.existingLedgerRequest.getServiceInstance().getId());
+        doReturn(this.existingLedgerRequest).when(this.ledgerRequestRepo).save(this.existingLedgerRequest);
+        doCallRealMethod().when(this.smartContractProvider).createNewServiceInstance(any());
+
+        // Mock the We3j transaction calls
+        doReturn(this.remoteFunctionCall).when(this.msrContract).registerServiceInstance(any(), any());
+        doReturn(this.completableFuture).when(this.remoteFunctionCall).sendAsync();
+        doReturn("0x1").when(this.transactionReceipt).getStatus();
+
+        // Perform the service call
+        this.ledgerRequestService.registerInstanceToLedger(this.existingLedgerRequest.getId());
+
+        // Make sure we updated the ledger request status twice, once with
+        // requesting and once with succeeded after the ledger Web3j call.
+        verify(this.ledgerRequestService, times(1)).updateStatus(this.existingLedgerRequest.getId(), LedgerRequestStatus.REQUESTING, null, Boolean.TRUE);
+        verify(this.ledgerRequestService, times(1)).updateStatus(eq(this.existingLedgerRequest.getId()), eq(LedgerRequestStatus.SUCCEEDED), any(String.class), eq(Boolean.TRUE));
+    }
+
+    /**
+     * Test that we if we fail to successfully register an instance to the
+     * ledger, the final status of the ledger request will be set to failed.
+     */
+    @Test
+    void testRegisterInstanceToLedgerFailed() {
+        // Set the status to REQUESTING
+        this.existingLedgerRequest.setStatus(LedgerRequestStatus.VETTED);
+
+        doReturn(this.msrContract).when(this.smartContractProvider).getMsrContract();
+        doReturn(this.existingLedgerRequest).when(this.ledgerRequestService).findOne(this.existingLedgerRequest.getId());
+        doReturn(Boolean.TRUE).when(this.ledgerRequestRepo).existsById(this.existingLedgerRequest.getId());
+        doReturn(Optional.of(this.existingLedgerRequest)).when(this.ledgerRequestRepo).findById(this.existingLedgerRequest.getId());
+        doReturn(this.instance).when(this.instanceService).findOne(this.existingLedgerRequest.getServiceInstance().getId());
+        doReturn(this.existingLedgerRequest).when(this.ledgerRequestRepo).save(this.existingLedgerRequest);
+        doCallRealMethod().when(this.smartContractProvider).createNewServiceInstance(any());
+
+        // Mock the We3j transaction calls
+        doReturn(this.remoteFunctionCall).when(this.msrContract).registerServiceInstance(any(), any());
+        doReturn(this.completableFuture).when(this.remoteFunctionCall).sendAsync();
+        doReturn("0x2").when(this.transactionReceipt).getStatus();
+
+        // Perform the service call
+        this.ledgerRequestService.registerInstanceToLedger(this.existingLedgerRequest.getId());
+
+        // Make sure we updated the ledger request status twice, once with
+        // requesting and once with succeeded after the ledger Web3j call.
+        verify(this.ledgerRequestService, times(1)).updateStatus(this.existingLedgerRequest.getId(), LedgerRequestStatus.REQUESTING, null, Boolean.TRUE);
+        verify(this.ledgerRequestService, times(1)).updateStatus(eq(this.existingLedgerRequest.getId()), eq(LedgerRequestStatus.FAILED), any(String.class), eq(Boolean.TRUE));
+    }
+
+    /**
+     * Test that we if we fail to successfully register an instance to the
+     * ledger with an exception, the final status of the ledger request will be
+     * set to failed.
+     */
+    @Test
+    void testRegisterInstanceToLedgerWithException() {
+        // Set the status to REQUESTING
+        this.existingLedgerRequest.setStatus(LedgerRequestStatus.VETTED);
+
+        doReturn(this.msrContract).when(this.smartContractProvider).getMsrContract();
+        doReturn(this.existingLedgerRequest).when(this.ledgerRequestService).findOne(this.existingLedgerRequest.getId());
+        doReturn(Boolean.TRUE).when(this.ledgerRequestRepo).existsById(this.existingLedgerRequest.getId());
+        doReturn(Optional.of(this.existingLedgerRequest)).when(this.ledgerRequestRepo).findById(this.existingLedgerRequest.getId());
+        doReturn(this.instance).when(this.instanceService).findOne(this.existingLedgerRequest.getServiceInstance().getId());
+        doReturn(this.existingLedgerRequest).when(this.ledgerRequestRepo).save(this.existingLedgerRequest);
+        doCallRealMethod().when(this.smartContractProvider).createNewServiceInstance(any());
+
+        // Mock the We3j transaction calls
+        doReturn(this.remoteFunctionCall).when(this.msrContract).registerServiceInstance(any(), any());
+        doReturn(this.completableFutureWithEx).when(this.remoteFunctionCall).sendAsync();
+
+        // Perform the service call
+        this.ledgerRequestService.registerInstanceToLedger(this.existingLedgerRequest.getId());
+
+        // Make sure we updated the ledger request status twice, once with
+        // requesting and once with succeeded after the ledger Web3j call.
+        verify(this.ledgerRequestService, times(1)).updateStatus(this.existingLedgerRequest.getId(), LedgerRequestStatus.REQUESTING, null, Boolean.TRUE);
+        verify(this.ledgerRequestService, times(1)).updateStatus(eq(this.existingLedgerRequest.getId()), eq(LedgerRequestStatus.FAILED), any(String.class), eq(Boolean.TRUE));
+    }
 }

--- a/src/test/java/net/maritimeconnectivity/serviceregistry/services/LedgerRequestServiceTest.java
+++ b/src/test/java/net/maritimeconnectivity/serviceregistry/services/LedgerRequestServiceTest.java
@@ -84,7 +84,7 @@ class LedgerRequestServiceTest {
     private LedgerRequest existingLedgerRequest;
     private MsrContract msrContract;
 
-    // The We3j transaction calls
+    // For the We3j transaction calls
     private RemoteFunctionCall remoteFunctionCall;
     private CompletableFuture completableFuture;
     private CompletableFuture completableFutureWithEx;
@@ -144,7 +144,7 @@ class LedgerRequestServiceTest {
         // Mock an MSR smart contract
         this.msrContract = mock(MsrContract.class);
 
-        // Mock the Web3j remove function call and response
+        // Mock the Web3j remote function call and response
         this.remoteFunctionCall = mock(RemoteFunctionCall.class);
         this.transactionReceipt = mock(TransactionReceipt.class);
 
@@ -576,7 +576,7 @@ class LedgerRequestServiceTest {
         this.ledgerRequestService.registerInstanceToLedger(this.existingLedgerRequest.getId());
 
         // Make sure we updated the ledger request status twice, once with
-        // requesting and once with succeeded after the ledger Web3j call.
+        // requesting and once with failure after the ledger Web3j call.
         verify(this.ledgerRequestService, times(1)).updateStatus(this.existingLedgerRequest.getId(), LedgerRequestStatus.REQUESTING, null, Boolean.TRUE);
         verify(this.ledgerRequestService, times(1)).updateStatus(eq(this.existingLedgerRequest.getId()), eq(LedgerRequestStatus.FAILED), any(String.class), eq(Boolean.TRUE));
     }
@@ -607,7 +607,7 @@ class LedgerRequestServiceTest {
         this.ledgerRequestService.registerInstanceToLedger(this.existingLedgerRequest.getId());
 
         // Make sure we updated the ledger request status twice, once with
-        // requesting and once with succeeded after the ledger Web3j call.
+        // requesting and once with failure after the ledger Web3j call.
         verify(this.ledgerRequestService, times(1)).updateStatus(this.existingLedgerRequest.getId(), LedgerRequestStatus.REQUESTING, null, Boolean.TRUE);
         verify(this.ledgerRequestService, times(1)).updateStatus(eq(this.existingLedgerRequest.getId()), eq(LedgerRequestStatus.FAILED), any(String.class), eq(Boolean.TRUE));
     }


### PR DESCRIPTION
We can now upload the instance doc through the front-end.
I made some changes so that the instance as doc field is lazy-loaded and not returned in our datatables. This makes things much faster when loading multiple instances.
We also have a separate DTO for the datatables which only contains the doc ID and name. Then we can download the doc if required separately.