### PR TITLE
Allowing WKT-based Geo-Spatial Searches

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,6 @@
 			<artifactId>bootstrap</artifactId>
 			<version>${bootstrap.version}</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>font-awesome</artifactId>
@@ -228,6 +227,11 @@
 					<artifactId>bootstrap</artifactId>
 				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.webjars.bowergithub.esri</groupId>
+			<artifactId>terraformer-wkt-parser</artifactId>
+			<version>1.2.0</version>
 		</dependency>
 
 		<!-- Testing -->

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/services/InstanceService.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/services/InstanceService.java
@@ -654,6 +654,7 @@ public class InstanceService {
         MultiFieldQueryParser parser = new MultiFieldQueryParser(this.searchFields, new StandardAnalyzer());
         parser.setDefaultOperator( QueryParser.Operator.AND );
         return Optional.ofNullable(queryString)
+                .filter(StringUtils::isNotBlank)
                 .map(q -> {
                     try {
                         return parser.parse(q);
@@ -676,7 +677,7 @@ public class InstanceService {
     protected Query createGeoSpatialQuery(Geometry geometry) {
         // Initialise the spatial strategy
         JtsSpatialContext ctx = JtsSpatialContext.GEO;
-        int maxLevels = 11; //results in sub-meter precision for geohash
+        int maxLevels = 12; //results in sub-meter precision for geohash
         SpatialPrefixTree grid = new GeohashPrefixTree(ctx, maxLevels);
         RecursivePrefixTreeStrategy strategy = new RecursivePrefixTreeStrategy(grid,"geometry");
 

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/utils/WKTUtil.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/utils/WKTUtil.java
@@ -22,10 +22,10 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 
-import java.io.IOException;
-
 /**
- * The type Wkt util.
+ * The WKTUtil class.
+ *
+ * A helper utility that manipulates the WKT geometry strings.
  *
  * @author Nikolaos Vastardis (email: Nikolaos.Vastardis@gla-rad.org)
  */
@@ -33,20 +33,27 @@ import java.io.IOException;
 public class WKTUtil {
 
     /**
+     * Converts a WKT geometry into a JTS geometry
+     *
+     * @param geometryAsWKT The geometry in WKT format
+     * @return a JTS geometry
+     * @throws ParseException if the WKT geometry was invalid
+     */
+    public static Geometry convertWKTtoGeometry(String geometryAsWKT) throws ParseException {
+        WKTReader wktReader = new WKTReader();
+        Geometry geometry = wktReader.read(geometryAsWKT);
+        return geometry;
+    }
+
+    /**
      * Converts a WKT geometry into GeoJson format, via JTS geometry
      *
      * @param geometryAsWKT The geometry in WKT format
      * @return JsonNode with the geometry expressed in GeoJson format
      * @throws ParseException if the WKT geometry was invalid
-     * @throws IOException    if the geoJson string could not be read by the Json parser
      */
     public static JsonNode convertWKTtoGeoJson(String geometryAsWKT) throws ParseException {
-        WKTReader wktReader = new WKTReader();
-        Geometry geometry = wktReader.read(geometryAsWKT);
-        if (geometry == null) {
-            log.debug("WKT geometry parsing error");
-        }
-        return GeometryJSONConverter.convertFromGeometry(geometry);
+        return GeometryJSONConverter.convertFromGeometry(WKTUtil.convertWKTtoGeometry(geometryAsWKT));
     }
 
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -102,21 +102,35 @@
                                         here
                                     </a>.
                                 </small></p>
-                                <div class="input-group mb3">
-                                    <span class="input-group-text" id="search-label">Search</span>
-                                    <input type="text" class="form-control" id="queryString" placeholder="field:value" aria-label="Query" aria-describedby="search-label">
-                                    <button type="button" class="btn btn-outline-primary" id="instanceSearchButton" onclick="searchForInstances()" title="Perform Search"><i class="fas fa-search"></i></button>
-                                    <button type="button" class="btn btn-outline-primary" id="instanceGeoSearchButton" onclick="geoSearchForInstances()" data-bs-toggle="button" autocomplete="off" title="Define Spatial Parameters">
-                                        <i class="fas fa-map-marked"></i>
-                                    </button>
-                                    <button type="button" class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
-                                        <span class="visually-hidden">Search Type Dropdown</span>
-                                    </button>
-                                    <ul class="dropdown-menu dropdown-menu-end">
-                                        <li><a class="dropdown-item">Global Search</a></li>
-                                        <li><a class="dropdown-item">Local Search</a></li>
-                                    </ul>
-                                    </br>
+                                <div class="row mb-3">
+                                    <div class="col-md-8 col-lg-9">
+                                        <div class="input-group">
+                                            <span class="input-group-text" id="search-label">Search</span>
+                                            <input type="text" class="form-control" id="queryString" placeholder="field1:value1 AND/OR field2:value2" aria-label="Query" aria-describedby="search-label">
+                                            <button type="button" class="btn btn-outline-primary" id="instanceSearchButton" onclick="searchForInstances()" title="Perform Search"><i class="fas fa-search"></i></button>
+                                            <button type="button" class="btn btn-outline-primary" id="instanceGeoSearchButton" onclick="geoSearchForInstances()" data-bs-toggle="button" autocomplete="off" title="Define Spatial Parameters">
+                                                <i class="fas fa-map-marked"></i>
+                                            </button>
+                                            <button type="button" class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+                                                <span class="visually-hidden">Search Type Dropdown</span>
+                                            </button>
+                                            <ul class="dropdown-menu dropdown-menu-end">
+                                                <li><a class="dropdown-item" onclick="setGeoSpatialSearchMode('geoJson')">Use GeoJSON</a></li>
+                                                <li><a class="dropdown-item" onclick="setGeoSpatialSearchMode('WKT')">Use WKT</a></li>
+                                            </ul>
+                                            </br>
+                                        </div>
+                                    </div>
+                                    <div class="col">
+                                        <select class="form-select">
+                                            <option value="global" selected>Global Search</option>
+                                            <option value="local">Local Search</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div id="geometryWKTArea" class="mb-3" style="display:none;">
+                                    <label for="geometryWKT" class="form-label">Geometry in WKT</label>
+                                    <textarea class="form-control" id="geometryWKT" rows="3" disabled></textarea>
                                 </div>
                                 <table id="instancesTable" class="table table-sm table-striped row-border hover w-100">
                                 </table>
@@ -137,6 +151,8 @@
     <script th:src="@{/webjars/bootstrap/js/bootstrap.min.js}"></script>
     <script th:src="@{/webjars/leaflet/dist/leaflet.js}"></script>
     <script th:src="@{/webjars/leaflet-draw/dist/leaflet.draw.js}"></script>
+    <script th:src="@{/webjars/terraformer/terraformer.min.js}"></script>
+    <script th:src="@{/webjars/terraformer-wkt-parser/terraformer-wkt-parser.min.js}"></script>
     <script src="https://cdn.datatables.net/1.11.0/js/jquery.dataTables.js" ></script>
     <script src="https://cdn.datatables.net/1.11.0/js/dataTables.bootstrap5.min.js" ></script>
     <script src="https://cdn.datatables.net/select/1.3.1/js/dataTables.select.js" ></script>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -102,37 +102,34 @@
                                         here
                                     </a>.
                                 </small></p>
-                                <div class="row mb-3">
-                                    <div class="col-md-8 col-lg-9">
-                                        <div class="input-group">
-                                            <span class="input-group-text" id="search-label">Search</span>
-                                            <input type="text" class="form-control" id="queryString" placeholder="field1:value1 AND/OR field2:value2" aria-label="Query" aria-describedby="search-label">
-                                            <button type="button" class="btn btn-outline-primary" id="instanceSearchButton" onclick="searchForInstances()" title="Perform Search"><i class="fas fa-search"></i></button>
-                                            <button type="button" class="btn btn-outline-primary" id="instanceGeoSearchButton" onclick="geoSearchForInstances()" data-bs-toggle="button" autocomplete="off" title="Define Spatial Parameters">
-                                                <i class="fas fa-map-marked"></i>
-                                            </button>
-                                            <button type="button" class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
-                                                <span class="visually-hidden">Search Type Dropdown</span>
-                                            </button>
-                                            <ul class="dropdown-menu dropdown-menu-end">
-                                                <li><a class="dropdown-item" onclick="setGeoSpatialSearchMode('geoJson')">Use GeoJSON</a></li>
-                                                <li><a class="dropdown-item" onclick="setGeoSpatialSearchMode('WKT')">Use WKT</a></li>
-                                            </ul>
-                                            </br>
-                                        </div>
-                                    </div>
-                                    <div class="col">
-                                        <select class="form-select">
-                                            <option value="global" selected>Global Search</option>
-                                            <option value="local">Local Search</option>
-                                        </select>
-                                    </div>
+                                <div class="input-group mb-3">
+                                    <span class="input-group-text" id="search-label">Search</span>
+                                    <input type="text" class="form-control" id="queryString" placeholder="field1:value1 AND/OR field2:value2" aria-label="Query" aria-describedby="search-label">
+                                    <button type="button" class="btn btn-outline-primary" id="instanceSearchButton" onclick="searchForInstances()" title="Perform Search"><i class="fas fa-search"></i></button>
+                                    <button type="button" class="btn btn-outline-primary" id="instanceGeoSearchButton" onclick="geoSearchForInstances()" data-bs-toggle="button" autocomplete="off" title="Define Spatial Parameters">
+                                        <i class="fas fa-map-marked"></i>
+                                    </button>
+                                    <button type="button" class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+                                        <span class="visually-hidden">Search Type Dropdown</span>
+                                    </button>
+                                    <ul class="dropdown-menu dropdown-menu-end">
+                                        <li><a class="dropdown-item" onclick="setGeoSpatialSearchMode('geoJson')">
+                                            <span id="geoJsonOption" class="fw-bold">Use GeoJSON</span>
+                                        </a></li>
+                                        <li><a class="dropdown-item" onclick="setGeoSpatialSearchMode('WKT')">
+                                            <span id="WKTOption" class="">Use WKT</span>
+                                        </a></li>
+                                    </ul>
+                                    <select id="searchType" class="form-select" style="max-width: 150px;">
+                                        <option value="global" selected>Global Search</option>
+                                        <option value="local">Local Search</option>
+                                    </select>
                                 </div>
                                 <div id="geometryWKTArea" class="mb-3" style="display:none;">
                                     <label for="geometryWKT" class="form-label">Geometry in WKT</label>
-                                    <textarea class="form-control" id="geometryWKT" rows="3" disabled></textarea>
+                                    <textarea class="form-control" id="geometryWKT" rows="3"></textarea>
                                 </div>
-                                <table id="instancesTable" class="table table-sm table-striped row-border hover w-100">
+                                <table id="instancesTable" class="table table-sm table-striped row-border hover border shadow w-100">
                                 </table>
                             </div>
                         </div>

--- a/src/test/java/net/maritimeconnectivity/serviceregistry/utils/WKTUtilTest.java
+++ b/src/test/java/net/maritimeconnectivity/serviceregistry/utils/WKTUtilTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2021 Maritime Connectivity Platform Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.maritimeconnectivity.serviceregistry.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.io.ParseException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WKTUtilTest {
+
+    // Test Variables
+    private Geometry point;
+    private Geometry lineString;
+    private Geometry polygon;
+    private JsonNode pointJson;
+    private JsonNode lineStringJson;
+    private JsonNode polygonJson;
+
+    /**
+     * Common setup for all the tests.
+     */
+    @BeforeEach
+    void setUp() {
+        // Create a temp geometry factory to get various geometries for testing
+        GeometryFactory factory = new GeometryFactory();
+        this.point = factory.createPoint(new Coordinate(52.001, 1.002));
+        this.lineString = factory.createLineString(new Coordinate[]{
+                new Coordinate(52.001, 1.002),
+                new Coordinate(53.001, 2.002)
+        });
+        this.polygon = factory.createPolygon(new Coordinate[]{
+                new Coordinate(52.001, 1.002),
+                new Coordinate(53.001, 1.002),
+                new Coordinate(53.001, 2.002),
+                new Coordinate(52.001, 2.002),
+                new Coordinate(52.001, 1.002),
+        });
+
+        // Translate the geometries into Geo JSON
+        this.pointJson = GeometryJSONConverter.convertFromGeometry(this.point);
+        this.lineStringJson = GeometryJSONConverter.convertFromGeometry(this.lineString);
+        this.polygonJson = GeometryJSONConverter.convertFromGeometry(this.polygon);
+    }
+
+    /**
+     * Test that we can correctly convert a WKT string into a Geometry object
+     *
+     * @throws ParseException when the WKT is invalid
+     */
+    @Test
+    void testConvertWKTtoGeometry() throws ParseException {
+        assertEquals(this.point, WKTUtil.convertWKTtoGeometry("POINT (52.001 1.002)"));
+        assertEquals(this.lineString, WKTUtil.convertWKTtoGeometry("LINESTRING (52.001 1.002, 53.001 2.002)"));
+        assertEquals(this.polygon, WKTUtil.convertWKTtoGeometry("POLYGON ((52.001 1.002, 53.001 1.002, 53.001 2.002, 52.001 2.002, 52.001 1.002))"));
+    }
+
+    /**
+     * Test that a ParseException will be thrown if an invalid WKT string is
+     * provided
+     */
+    @Test
+    void testConvertWKTtoGeometryInvalid() {
+        assertThrows(ParseException.class, () -> WKTUtil.convertWKTtoGeometry("This doesn't make sense!"));
+    }
+
+    /**
+     * Test that we can correctly convert a WKT string into a GeoJSON object
+     *
+     * @throws ParseException when the WKT is invalid
+     */
+    @Test
+    void testConvertWKTtoGeoJson() throws ParseException {
+        assertEquals(this.pointJson, WKTUtil.convertWKTtoGeoJson("POINT (52.001 1.002)"));
+        assertEquals(this.lineStringJson, WKTUtil.convertWKTtoGeoJson(("LINESTRING (52.001 1.002, 53.001 2.002)")));
+        assertEquals(this.polygonJson, WKTUtil.convertWKTtoGeoJson(("POLYGON ((52.001 1.002, 53.001 1.002, 53.001 2.002, 52.001 2.002, 52.001 1.002))")));
+    }
+
+    /**
+     * Test that a ParseException will be thrown if an invalid WKT string is
+     * provided
+     */
+    @Test
+    void testConvertWKTtoGeoJsonInvalid() {
+        assertThrows(ParseException.class, () -> WKTUtil.convertWKTtoGeoJson("This doesn't make sense!"));
+    }
+
+}


### PR DESCRIPTION
Another relatively small change to allow geo-spatial location searches using WKT formatting, besides GeoJSON. Most changes are in the front-end where a textarea field is now visible to allow the users to view and even change the WKT string. In the back-end the WKT string is parsed into a geometry so nothing really changes after that point.