### PR TITLE
Add BouncyCastle as a crypto provider

### DIFF
--- a/src/main/java/net/maritimeconnectivity/serviceregistry/McpServRegApplication.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/McpServRegApplication.java
@@ -16,8 +16,11 @@
 
 package net.maritimeconnectivity.serviceregistry;
 
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.security.Security;
 
 /**
  * The MCP Service Registry Application.
@@ -28,6 +31,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class McpServRegApplication {
 
 	public static void main(String[] args) {
+		Security.addProvider(new BouncyCastleProvider());
 		SpringApplication.run(McpServRegApplication.class, args);
 	}
 


### PR DESCRIPTION
This fixes a bug that causes the MSR to not be able to validate OIDC tokens from Keycloak that contain an ECDSA signature