### PR TITLE
Fixed OpenAPI definition generation of paging parameters

### DIFF
--- a/src/main/java/net/maritimeconnectivity/serviceregistry/controllers/DocController.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/controllers/DocController.java
@@ -29,6 +29,7 @@ import net.maritimeconnectivity.serviceregistry.models.dto.datatables.DtPagingRe
 import net.maritimeconnectivity.serviceregistry.services.DocService;
 import net.maritimeconnectivity.serviceregistry.utils.HeaderUtil;
 import net.maritimeconnectivity.serviceregistry.utils.PaginationUtil;
+import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -90,7 +91,7 @@ public class DocController {
      * @throws URISyntaxException if there is an error to generate the pagination HTTP headers
      */
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<List<DocDto>> getDocs(Pageable pageable) throws URISyntaxException {
+    public ResponseEntity<List<DocDto>> getDocs(@ParameterObject Pageable pageable) throws URISyntaxException {
         log.debug("REST request to get a page of Docs");
         final Page<Doc> page = this.docService.findAll(pageable);
         return ResponseEntity.ok()

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/controllers/InstanceController.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/controllers/InstanceController.java
@@ -32,6 +32,7 @@ import net.maritimeconnectivity.serviceregistry.utils.HeaderUtil;
 import net.maritimeconnectivity.serviceregistry.utils.PaginationUtil;
 import org.iala_aism.g1128.v1_3.servicespecificationschema.ServiceStatus;
 import org.modelmapper.PropertyMap;
+import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -115,7 +116,7 @@ public class InstanceController {
      * @throws URISyntaxException if there is an error to generate the pagination HTTP headers
      */
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<List<InstanceDto>> getInstances(Pageable pageable) throws URISyntaxException {
+    public ResponseEntity<List<InstanceDto>> getInstances(@ParameterObject Pageable pageable) throws URISyntaxException {
         log.debug("REST request to get a page of Instances");
         final Page<Instance> page = this.instanceService.findAll(pageable);
         return ResponseEntity.ok()

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/controllers/LedgerRequestController.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/controllers/LedgerRequestController.java
@@ -26,6 +26,7 @@ import net.maritimeconnectivity.serviceregistry.models.dto.LedgerRequestDto;
 import net.maritimeconnectivity.serviceregistry.services.LedgerRequestService;
 import net.maritimeconnectivity.serviceregistry.utils.HeaderUtil;
 import net.maritimeconnectivity.serviceregistry.utils.PaginationUtil;
+import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.data.domain.Page;
@@ -72,7 +73,7 @@ public class LedgerRequestController {
      * @throws URISyntaxException if there is an error to generate the pagination HTTP headers
      */
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<List<LedgerRequestDto>> getLedgerRequests(Pageable pageable) throws URISyntaxException {
+    public ResponseEntity<List<LedgerRequestDto>> getLedgerRequests(@ParameterObject Pageable pageable) throws URISyntaxException {
         log.debug("REST request to get a page of LedgerRequests");
         final Page<LedgerRequest> page = this.ledgerRequestService.findAll(pageable);
         return ResponseEntity.ok()

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/controllers/SearchController.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/controllers/SearchController.java
@@ -28,6 +28,7 @@ import net.maritimeconnectivity.serviceregistry.utils.PaginationUtil;
 import net.maritimeconnectivity.serviceregistry.utils.WKTUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.locationtech.jts.geom.Geometry;
+import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -81,7 +82,7 @@ public class SearchController {
                                                              @RequestParam(value = "geometry") Optional<Geometry> geometry,
                                                              @RequestParam(value = "geometryWKT") Optional<String> geometryWKT,
                                                              @RequestParam(value = "globalSearch") Optional<Boolean> globalSearch,
-                                                             Pageable pageable) throws URISyntaxException {
+                                                             @ParameterObject Pageable pageable) throws URISyntaxException {
         // We only allow one geometry specification method
         if(geometry.isPresent() && geometryWKT.filter(StringUtils::isNotBlank).isPresent()) {
             return ResponseEntity.badRequest()

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/controllers/XmlController.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/controllers/XmlController.java
@@ -27,6 +27,7 @@ import net.maritimeconnectivity.serviceregistry.services.XmlService;
 import net.maritimeconnectivity.serviceregistry.utils.HeaderUtil;
 import net.maritimeconnectivity.serviceregistry.utils.PaginationUtil;
 import org.apache.commons.io.IOUtils;
+import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -81,7 +82,7 @@ public class XmlController {
      * @throws URISyntaxException if there is an error to generate the pagination HTTP headers
      */
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<List<XmlDto>> getAllXmls(Pageable pageable)
+    public ResponseEntity<List<XmlDto>> getAllXmls(@ParameterObject Pageable pageable)
             throws URISyntaxException {
         log.debug("REST request to get a page of Xmls");
         final Page<Xml> page = this.xmlService.findAll(pageable);


### PR DESCRIPTION
The Pageable object that is taken as a parameter to endpoints that support was previously being translated to a JSON object that should be given as query parameter which is not allowed in GET calls. Adding the @ParameterObject annotation tells springdoc that a Pageable object should be translated to paging attributes (page, size and sort) instead of a JSON object.