### PR TITLE
Adding support for requests with JWT tokens

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,5 +36,5 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: docker
-        tags: ghcr.io/gla-rad/serviceregistry
+        tags: ghcr.io/maritimeconnectivity/serviceregistry
         push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,5 +36,5 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: docker
-        tags: ghcr.io/maritimeconnectivity/serviceregistry
+        tags: ghcr.io/gla-rad/serviceregistry
         push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ build/
 ### macOS ###
 .DS_Store
 
+### Skip certs ###
+/certs/
+

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.5</version>
+		<version>3.2.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -18,7 +18,7 @@
 
 	<properties>
 		<java.version>21</java.version>
-		<spring-cloud.version>2023.0.1</spring-cloud.version>
+		<spring-cloud.version>2023.0.2</spring-cloud.version>
 		<springdoc.version>2.5.0</springdoc.version>
 		<bootstrap.version>5.3.2</bootstrap.version>
 		<jquery.version>3.7.1</jquery.version>


### PR DESCRIPTION
When generating service instance entries in the Service Registry, the system will check the authentication token from the user request and pick up the organization information from there.

This works find for requests coming users through the OAuth2 flow.

However, for requests that fort example come through the Management Portal, or other API requests, previously it did not pick up correctly that information since the authentication type (JWT) was not supported.

This has now been fixed, and additional unit-tests have been added to prove it.
