### PR TITLE
Using a blank geometry for instances when none is provided

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,5 +36,5 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: docker
-        tags: ghcr.io/gla-rad/serviceregistry
+        tags: ghcr.io/maritimeconnectivity/serviceregistry
         push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,5 +36,5 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: docker
-        tags: ghcr.io/maritimeconnectivity/serviceregistry
+        tags: ghcr.io/gla-rad/serviceregistry
         push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ build/
 ### macOS ###
 .DS_Store
 
+### Skip certs ###
+/certs/
+

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.5</version>
+		<version>3.2.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -18,7 +18,7 @@
 
 	<properties>
 		<java.version>21</java.version>
-		<spring-cloud.version>2023.0.1</spring-cloud.version>
+		<spring-cloud.version>2023.0.2</spring-cloud.version>
 		<springdoc.version>2.5.0</springdoc.version>
 		<bootstrap.version>5.3.2</bootstrap.version>
 		<jquery.version>3.7.1</jquery.version>

--- a/src/test/java/net/maritimeconnectivity/serviceregistry/services/InstanceServiceTest.java
+++ b/src/test/java/net/maritimeconnectivity/serviceregistry/services/InstanceServiceTest.java
@@ -346,8 +346,8 @@ class InstanceServiceTest {
 
         // Check the geometry
         assertNotNull(result.getGeometry());
-        assertEquals(new ObjectMapper().readTree(this.instanceService.wholeWorldGeoJson).get("type"), result.getGeometryJson().get("type"));
-        assertEquals(new ObjectMapper().readTree(this.instanceService.wholeWorldGeoJson).get("coordinates"), result.getGeometryJson().get("coordinates"));
+        assertFalse(result.getGeometryJson().get("type").isNull());
+        assertTrue(result.getGeometryJson().get("coordinates").isEmpty());
 
         // Also that a saving call took place in the repository
         verify(this.instanceRepo, times(1)).save(this.newInstance);
@@ -610,16 +610,16 @@ class InstanceServiceTest {
         // Set the pagination request columns
         dtPagingRequest.setColumns(new ArrayList());
         Stream.of("name",
-                "version",
-                "lastUpdatedAt",
-                "instanceId",
-                "keywords",
-                "status",
-                "organizationId",
-                "endpointUri",
-                "mmsi",
-                "imo",
-                "serviceType")
+                        "version",
+                        "lastUpdatedAt",
+                        "instanceId",
+                        "keywords",
+                        "status",
+                        "organizationId",
+                        "endpointUri",
+                        "mmsi",
+                        "imo",
+                        "serviceType")
                 .map(DtColumn::new)
                 .forEach(dtPagingRequest.getColumns()::add);
 


### PR DESCRIPTION
When generating a new service instance, for emtpy geometries, the system previously added the whole earth as the default value.

This is no longer the case, and services with empty geometries will will be assigned to a blank (but not null) geometry.
