### PR TITLE
Updating Springboot and SECOMLib Versions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,5 +36,5 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: docker
-        tags: ghcr.io/gla-rad/serviceregistry
+        tags: ghcr.io/maritimeconnectivity/serviceregistry
         push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,5 +36,5 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: docker
-        tags: ghcr.io/maritimeconnectivity/serviceregistry
+        tags: ghcr.io/gla-rad/serviceregistry
         push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Build like this:
 #     docker build -t <version> -f Dockerfile ..
 # e.g.
-#     docker build -t glarad/mc-service-registry:latest -f Dockerfile ..
+#     docker build -t maritimeconnectivity/mc-service-registry:latest -f Dockerfile ..
 #
 # Run like this:
 #     sudo docker run -t -i --rm -p 8444:8444 -v /path/to/config-directory/on/machine:/conf <image-id>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.6</version>
+		<version>3.3.4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -18,13 +18,13 @@
 
 	<properties>
 		<java.version>21</java.version>
-		<spring-cloud.version>2023.0.2</spring-cloud.version>
+		<spring-cloud.version>2023.0.3</spring-cloud.version>
 		<springdoc.version>2.5.0</springdoc.version>
 		<bootstrap.version>5.3.2</bootstrap.version>
 		<jquery.version>3.7.1</jquery.version>
 		<fa.version>6.5.1</fa.version>
-		<hibernate.spatial.version>6.4.1.Final</hibernate.spatial.version>
-		<hibernate.search-orm.version>7.0.0.Final</hibernate.search-orm.version>
+		<hibernate.search-orm.version>7.1.1.Final</hibernate.search-orm.version>
+		<hibernate.spatial.version>6.4.4.Final</hibernate.spatial.version>
 		<lucene.spatial.version>9.8.0</lucene.spatial.version>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -219,13 +219,8 @@
 		<!-- SECOM -->
 		<dependency>
 			<groupId>org.grad.secom</groupId>
-			<artifactId>secom-core-jakarta</artifactId>
-			<version>0.0.38</version>
-		</dependency>
-		<dependency>
-			<groupId>org.grad.secom</groupId>
 			<artifactId>secom-springboot3</artifactId>
-			<version>0.0.38</version>
+			<version>0.0.49</version>
 		</dependency>
 
 		<!-- G-1128 Schemas -->

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.10.0</version>
+			<version>2.14.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/config/GlobalConfig.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/config/GlobalConfig.java
@@ -20,6 +20,7 @@ import net.maritimeconnectivity.serviceregistry.models.domain.Instance;
 import net.maritimeconnectivity.serviceregistry.models.domain.Xml;
 import net.maritimeconnectivity.serviceregistry.models.dto.secom.SearchObjectResultWithCert;
 import net.maritimeconnectivity.serviceregistry.utils.GeometryJSONConverter;
+import org.apache.commons.lang3.StringUtils;
 import org.grad.secom.core.models.SearchObjectResult;
 import org.grad.secom.core.models.enums.SECOM_DataProductType;
 import org.locationtech.jts.geom.Geometry;
@@ -84,6 +85,12 @@ public class GlobalConfig {
         modelMapper.createTypeMap(Instance.class, SearchObjectResultWithCert.class)
                 .implicitMappings()
                 .addMappings(mapper -> {
+                    mapper.using(ctx -> Optional.of(ctx)
+                                    .map(MappingContext::getSource)
+                                    .map(Iterable.class::cast)
+                                    .map(kl -> String.join(",", kl))
+                                    .orElse(null))
+                            .map(Instance::getKeywords, SearchObjectResult::setKeywords);
                     mapper.using(ctx -> Optional.of(ctx)
                                     .map(MappingContext::getSource)
                                     .map(Xml.class::cast)

--- a/src/main/java/net/maritimeconnectivity/serviceregistry/controllers/secom/SecomSearchServiceController.java
+++ b/src/main/java/net/maritimeconnectivity/serviceregistry/controllers/secom/SecomSearchServiceController.java
@@ -173,9 +173,8 @@ public class SecomSearchServiceController implements SearchServiceSecomInterface
                 query = this.addToQuery(query, "unlocode", searchFilterObject.getQuery().getUnlocode(), BooleanOperator.AND);
             }
 
-            // Handle the endpoint URI filter
-            if (Objects.nonNull(searchFilterObject.getQuery().getEndpointUri())) {
-
+            // Handle the endpoint URI filter - make sure it's not empty
+            if (Objects.nonNull(searchFilterObject.getQuery().getEndpointUri()) && Strings.isNotBlank(searchFilterObject.getQuery().getEndpointUri().getPath())) {
                 query = this.addToQuery(query, "endpointUri", searchFilterObject.getQuery().getEndpointUri().toString(), BooleanOperator.AND);
             }
 


### PR DESCRIPTION
This pull container some minor version updates on Springboot and Apache Commons IO.

In addition it contains a more significant update on the SECOMLib that changes the Search Object Result keywords field from a List to a simple String... as per version 1.0.0 of SECOM. 

This will probably be reverted in the next SECOM version, but for now we need to change it. This is a "breaking" change so we should inform people and also update our own MCP portal to allow it to handle the new keywords type.

The pull also includes a minor fix to allow empty string endpoint fields to be pass for searching.

Finally, some already merged diffs appear, not sure why but these UserContext changes are already there